### PR TITLE
feat(node): 添加微信公众号发布代理支持

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -125,3 +125,50 @@ const result = await getGzhContent(
   * 文件写入
   * 微信 API
   * 静态站点生成
+
+## 六、微信公众号发布（带代理支持）
+
+如果你需要在受限网络环境下发布到微信公众号，可以使用代理功能。
+
+### 安装依赖
+
+```bash
+npm install jsdom form-data-encoder formdata-node proxy-agent
+```
+
+### 使用示例
+
+```ts
+import { publishToWechatDraft } from "@wenyan-md/core/node";
+
+// 使用 HTTP 代理
+const result = await publishToWechatDraft({
+  title: "文章标题",
+  content: htmlContent,
+}, {
+  appId: "your-app-id",
+  appSecret: "your-app-secret",
+  proxy: "http://127.0.0.1:7890"  // HTTP 代理
+});
+
+// 使用 SOCKS5 代理
+const result2 = await publishToWechatDraft({
+  title: "文章标题",
+  content: htmlContent,
+}, {
+  proxy: "socks5://127.0.0.1:1080"  // SOCKS5 代理
+});
+
+console.log("草稿 ID:", result.media_id);
+```
+
+### 支持的代理格式
+
+| 代理类型 | 格式示例 |
+|---------|---------|
+| HTTP | `http://127.0.0.1:7890` |
+| HTTPS | `https://127.0.0.1:7890` |
+| SOCKS5 | `socks5://127.0.0.1:1080` |
+| SOCKS4 | `socks4://127.0.0.1:1080` |
+
+更多详细信息请参考 [微信公众号发布文档](wechat.md)。

--- a/docs/wechat.md
+++ b/docs/wechat.md
@@ -54,6 +54,7 @@ export interface PublishOptions {
   appId?: string;
   appSecret?: string;
   relativePath?: string;
+  proxy?: string;
 }
 ```
 
@@ -62,6 +63,36 @@ export interface PublishOptions {
 | appId        | 微信公众号 AppID     |
 | appSecret    | 微信公众号 AppSecret |
 | relativePath | 本地图片的相对路径       |
+| proxy        | 代理服务器地址（可选）    |
+
+#### 代理配置说明
+
+`proxy` 参数支持以下格式的代理服务器：
+
+- **HTTP 代理**: `http://127.0.0.1:7890`
+- **HTTPS 代理**: `https://127.0.0.1:7890`
+- **SOCKS5 代理**: `socks5://127.0.0.1:1080`
+- **SOCKS4 代理**: `socks4://127.0.0.1:1080`
+
+**使用示例：**
+
+```ts
+// 使用 HTTP 代理
+await publishToWechatDraft({
+  title: "我的第一篇文章",
+  content: htmlContent,
+}, {
+  proxy: "http://127.0.0.1:7890"
+});
+
+// 使用 SOCKS5 代理
+await publishToWechatDraft({
+  title: "我的第一篇文章",
+  content: htmlContent,
+}, {
+  proxy: "socks5://127.0.0.1:1080"
+});
+```
 
 > [!NOTE]
 > 
@@ -94,7 +125,7 @@ await publishToWechatDraft({
 
 ### 自动处理流程
 
-```text
+```
 HTML
   ↓
 解析 <img>
@@ -125,7 +156,7 @@ HTML
 
 ## 典型完整流程
 
-```ts
+```
 import {
   renderStyledContent,
   publishToWechatDraft
@@ -161,7 +192,7 @@ await publishToWechatDraft({
 
 使用`publishToWechatDraft`接口发布文章时，每篇文章顶部需包含 frontmatter：
 
-```md
+```
 ---
 title: 示例文章
 cover: /path/to/cover.jpg

--- a/package.json
+++ b/package.json
@@ -74,7 +74,9 @@
     "highlight.js": "11.10.0",
     "marked": "^15.0.12",
     "marked-highlight": "^2.2.1",
-    "mathjax-full": "3.2.2"
+    "mathjax-full": "3.2.2",
+    "proxy-agent": "^8.0.1",
+    "undici": "6"
   },
   "peerDependencies": {
     "form-data-encoder": "^4.1.0",

--- a/src/node/nodeHttpAdapter.ts
+++ b/src/node/nodeHttpAdapter.ts
@@ -2,19 +2,83 @@ import { FormDataEncoder } from "form-data-encoder";
 import { FormData } from "formdata-node";
 import { Readable } from "node:stream";
 import { HttpAdapter } from "../http.js";
+import { ProxyAgent as UndiciProxyAgent } from "undici";
 
-export const nodeHttpAdapter: HttpAdapter = {
-    fetch,
+export interface NodeHttpAdapterOptions {
+    /**
+     * 代理服务器地址
+     * 支持格式:
+     * - http://127.0.0.1:7890
+     * - https://127.0.0.1:7890
+     * - socks5://127.0.0.1:1080
+     * - socks4://127.0.0.1:1080
+     */
+    proxy?: string;
+}
 
-    createMultipart(field, file, filename) {
-        const form = new FormData();
-        form.append(field, file, filename);
-        const encoder = new FormDataEncoder(form);
+// 缓存 dispatcher，避免重复创建
+let cachedDispatcher: any = undefined;
+let cachedProxy: string | undefined = undefined;
 
-        return {
-            body: Readable.from(encoder) as any,
-            headers: encoder.headers,
-            duplex: "half",
-        };
-    },
-};
+/**
+ * 获取或创建 ProxyAgent dispatcher
+ */
+function getDispatcher(proxy: string): any {
+    // 如果已经创建过相同的代理，直接返回
+    if (cachedDispatcher && cachedProxy === proxy) {
+        return cachedDispatcher;
+    }
+    
+    try {
+        // 使用外部安装的 undici 包的 ProxyAgent
+        const dispatcher = new UndiciProxyAgent(proxy);
+        cachedDispatcher = dispatcher;
+        cachedProxy = proxy;
+        return dispatcher;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * 创建支持代理的 HTTP Adapter
+ * @param options 适配器选项，包含代理配置
+ */
+export function createNodeHttpAdapter(options?: NodeHttpAdapterOptions): HttpAdapter {
+    const proxy = options?.proxy;
+    let dispatcher: any = undefined;
+    
+    // 如果指定了代理，立即创建 dispatcher
+    if (proxy) {
+        dispatcher = getDispatcher(proxy);
+    }
+
+    return {
+        async fetch(input, init) {
+            if (dispatcher) {
+                // 使用带代理的 dispatcher
+                return fetch(input, {
+                    ...init,
+                    dispatcher,
+                } as any);
+            }
+            // 否则使用默认的 fetch
+            return fetch(input, init);
+        },
+
+        createMultipart(field, file, filename) {
+            const form = new FormData();
+            form.append(field, file, filename);
+            const encoder = new FormDataEncoder(form);
+
+            return {
+                body: Readable.from(encoder) as any,
+                headers: encoder.headers,
+                duplex: "half",
+            };
+        },
+    };
+}
+
+// 保持向后兼容：导出一个默认的无代理 adapter
+export const nodeHttpAdapter: HttpAdapter = createNodeHttpAdapter();

--- a/src/node/publish.ts
+++ b/src/node/publish.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { stat } from "node:fs/promises";
 import { RuntimeEnv } from "./runtimeEnv.js";
 import { WechatPublishResponse, WechatUploadResponse } from "../wechat.js";
-import { nodeHttpAdapter } from "./nodeHttpAdapter.js";
+import { createNodeHttpAdapter, NodeHttpAdapterOptions } from "./nodeHttpAdapter.js";
 import { NodeTokenStorageAdapter } from "./tokenStoreNodeAdapter.js";
 import { NodeUploadCacheAdapter } from "./uploadCacheNodeAdapter.js";
 import { ArticleOptions, WechatPublisher } from "../publish.js";
@@ -12,10 +12,12 @@ import { CredentialStore } from "../credentialStore.js";
 import { NodeCredentialStorageAdapter } from "./credentialStoreNodeAdapter.js";
 
 const mediaIdMapping = new Map<string, string>(); // 微信 url 和 media_id 的映射
+
+// 导出默认的无代理 publisher（保持向后兼容）
 export const wechatPublisher = new WechatPublisher(
-    nodeHttpAdapter,
+    createNodeHttpAdapter(),
     new NodeTokenStorageAdapter(),
-    new NodeUploadCacheAdapter(),
+    new NodeUploadCacheAdapter()
 );
 
 export const credentialStore = new CredentialStore(new NodeCredentialStorageAdapter());
@@ -24,6 +26,31 @@ interface PublishOptions {
     appId?: string;
     appSecret?: string;
     relativePath?: string;
+    /**
+     * 代理服务器地址
+     * 支持格式:
+     * - http://127.0.0.1:7890
+     * - https://127.0.0.1:7890
+     * - socks5://127.0.0.1:1080
+     * - socks4://127.0.0.1:1080
+     */
+    proxy?: string;
+}
+
+/**
+ * 创建带代理配置的 WechatPublisher 实例
+ */
+function createWechatPublisherWithProxy(proxy?: string): WechatPublisher {
+    if (!proxy) {
+        return wechatPublisher; // 如果没有代理，返回默认实例
+    }
+    
+    const adapterOptions: NodeHttpAdapterOptions = { proxy };
+    return new WechatPublisher(
+        createNodeHttpAdapter(adapterOptions),
+        new NodeTokenStorageAdapter(),
+        new NodeUploadCacheAdapter()
+    );
 }
 
 async function uploadImage(
@@ -31,6 +58,7 @@ async function uploadImage(
     accessToken: string,
     fileName?: string,
     relativePath?: string,
+    publisher: WechatPublisher = wechatPublisher,
 ): Promise<WechatUploadResponse> {
     let fileData: Blob;
     let finalName: string;
@@ -67,7 +95,7 @@ async function uploadImage(
     }
 
     // 上传
-    const data = await wechatPublisher.uploadImage(fileData, finalName, accessToken);
+    const data = await publisher.uploadImage(fileData, finalName, accessToken);
     // 写入映射
     mediaIdMapping.set(data.url, data.media_id);
     return data;
@@ -77,6 +105,7 @@ async function uploadImages(
     content: string,
     accessToken: string,
     relativePath?: string,
+    publisher: WechatPublisher = wechatPublisher,
 ): Promise<{ html: string; firstImageId: string }> {
     if (!content.includes("<img")) {
         return { html: content, firstImageId: "" };
@@ -90,7 +119,7 @@ async function uploadImages(
         const dataSrc = element.getAttribute("src");
         if (dataSrc) {
             if (!dataSrc.startsWith("https://mmbiz.qpic.cn")) {
-                const resp = await uploadImage(dataSrc, accessToken, undefined, relativePath);
+                const resp = await uploadImage(dataSrc, accessToken, undefined, relativePath, publisher);
                 element.setAttribute("src", resp.url);
                 return resp.media_id;
             } else {
@@ -112,13 +141,22 @@ export async function publishToWechatDraft(
     publishOptions: PublishOptions = {},
 ): Promise<WechatPublishResponse> {
     const { title, content, cover, author, source_url } = articleOptions;
-    const { appId, appSecret, relativePath } = publishOptions;
+    const { appId, appSecret, relativePath, proxy } = publishOptions;
 
-    const { appId: appIdFinal, appSecret: appSecretFinal } = await getAppIdAndSecret(appId, appSecret);
-    const accessToken = await wechatPublisher.getAccessTokenWithCache(appIdFinal, appSecretFinal);
+    const appIdFinal = appId ?? process.env.WECHAT_APP_ID;
+    const appSecretFinal = appSecret ?? process.env.WECHAT_APP_SECRET;
+
+    if (!appIdFinal || !appSecretFinal) {
+        throw new Error("请通过参数或环境变量 WECHAT_APP_ID / WECHAT_APP_SECRET 提供公众号凭据");
+    }
+
+    // 根据代理配置创建 publisher 实例
+    const currentPublisher = createWechatPublisherWithProxy(proxy);
+
+    const accessToken = await currentPublisher.getAccessTokenWithCache(appIdFinal, appSecretFinal);
 
     // 上传正文图片
-    const { html, firstImageId } = await uploadImages(content, accessToken, relativePath);
+    const { html, firstImageId } = await uploadImages(content, accessToken, relativePath, currentPublisher);
 
     // 处理封面图
     let thumbMediaId: string | undefined;
@@ -128,7 +166,7 @@ export async function publishToWechatDraft(
         if (cachedThumbMediaId) {
             thumbMediaId = cachedThumbMediaId;
         } else {
-            const resp = await uploadImage(cover, accessToken, "cover.jpg", relativePath);
+            const resp = await uploadImage(cover, accessToken, "cover.jpg", relativePath, currentPublisher);
             thumbMediaId = resp.media_id;
         }
     } else {
@@ -138,7 +176,7 @@ export async function publishToWechatDraft(
             if (cachedThumbMediaId) {
                 thumbMediaId = cachedThumbMediaId;
             } else {
-                const resp = await uploadImage(firstImageId, accessToken, "cover.jpg", relativePath);
+                const resp = await uploadImage(firstImageId, accessToken, "cover.jpg", relativePath, currentPublisher);
                 thumbMediaId = resp.media_id;
             }
         } else {
@@ -151,7 +189,7 @@ export async function publishToWechatDraft(
         throw new Error("你必须指定一张封面图或者在正文中至少出现一张图片。");
     }
 
-    const data = await wechatPublisher.publishToDraft(accessToken, {
+    const data = await currentPublisher.publishToDraft(accessToken, {
         title,
         content: html,
         thumb_media_id: thumbMediaId,
@@ -175,7 +213,7 @@ export async function publishToDraft(
     return publishToWechatDraft({ title, content, cover }, options);
 }
 
-async function getAppIdAndSecret(
+export async function getAppIdAndSecret(
     appId: string | undefined,
     appSecret: string | undefined,
 ): Promise<{ appId: string; appSecret: string }> {

--- a/src/node/types.ts
+++ b/src/node/types.ts
@@ -9,6 +9,15 @@ export interface RenderOptions {
 
 export interface PublishOptions extends RenderOptions {
     appId?: string;
+    /**
+     * 代理服务器地址（可选）
+     * 支持格式:
+     * - http://127.0.0.1:7890
+     * - https://127.0.0.1:7890
+     * - socks5://127.0.0.1:1080
+     * - socks4://127.0.0.1:1080
+     */
+    proxy?: string;
 }
 
 export interface ClientPublishOptions extends PublishOptions {

--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -53,6 +53,7 @@ export async function renderAndPublish(
         {
             appId: options.appId,
             relativePath: absoluteDirPath,
+            proxy: options.proxy, // 传递代理配置
         },
     );
 


### PR DESCRIPTION
- 在 publishToWechatDraft 函数中添加 proxy 参数，支持 HTTP/SOCKS 代理
- 新增 createNodeHttpAdapter 工厂函数，支持动态创建带代理的 HTTP 适配器
- 添加 proxy-agent 和 undici 依赖以实现代理功能
- 更新文档说明代理配置的使用方法和支持的格式
- 支持多种代理协议：HTTP