### PR TITLE
fix: scope upload cache by appId to prevent cross-account media_id reuse

### DIFF
--- a/src/node/publish.ts
+++ b/src/node/publish.ts
@@ -22,6 +22,7 @@ async function uploadImage(
     accessToken: string,
     fileName?: string,
     relativePath?: string,
+    appId?: string,
 ): Promise<WechatUploadResponse> {
     let fileData: Blob;
     let finalName: string;
@@ -58,7 +59,7 @@ async function uploadImage(
     }
 
     // 上传
-    const data = await wechatPublisher.uploadImage(fileData, finalName, accessToken);
+    const data = await wechatPublisher.uploadImage(fileData, finalName, accessToken, appId);
     // 写入映射
     mediaIdMapping.set(data.url, data.media_id);
     return data;
@@ -68,6 +69,7 @@ async function uploadImages(
     content: string,
     accessToken: string,
     relativePath?: string,
+    appId?: string,
 ): Promise<{ html: string; firstImageId: string }> {
     if (!content.includes("<img")) {
         return { html: content, firstImageId: "" };
@@ -81,7 +83,7 @@ async function uploadImages(
         const dataSrc = element.getAttribute("src");
         if (dataSrc) {
             if (!dataSrc.startsWith("https://mmbiz.qpic.cn")) {
-                const resp = await uploadImage(dataSrc, accessToken, undefined, relativePath);
+                const resp = await uploadImage(dataSrc, accessToken, undefined, relativePath, appId);
                 element.setAttribute("src", resp.url);
                 return resp.media_id;
             } else {
@@ -115,7 +117,7 @@ export async function publishToWechatDraft(
     const accessToken = await wechatPublisher.getAccessTokenWithCache(appIdFinal, appSecretFinal);
 
     // 上传正文图片
-    const { html, firstImageId } = await uploadImages(content, accessToken, relativePath);
+    const { html, firstImageId } = await uploadImages(content, accessToken, relativePath, appIdFinal);
 
     // 处理封面图
     let thumbMediaId = "";
@@ -125,7 +127,7 @@ export async function publishToWechatDraft(
         if (cachedThumbMediaId) {
             thumbMediaId = cachedThumbMediaId;
         } else {
-            const resp = await uploadImage(cover, accessToken, "cover.jpg", relativePath);
+            const resp = await uploadImage(cover, accessToken, "cover.jpg", relativePath, appIdFinal);
             thumbMediaId = resp.media_id;
         }
     } else {
@@ -135,7 +137,7 @@ export async function publishToWechatDraft(
             if (cachedThumbMediaId) {
                 thumbMediaId = cachedThumbMediaId;
             } else {
-                const resp = await uploadImage(firstImageId, accessToken, "cover.jpg", relativePath);
+                const resp = await uploadImage(firstImageId, accessToken, "cover.jpg", relativePath, appIdFinal);
                 thumbMediaId = resp.media_id;
             }
         } else {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -51,12 +51,13 @@ export class WechatPublisher {
         return result.access_token;
     }
 
-    public async uploadImage(file: Blob, filename: string, accessToken: string): Promise<WechatUploadResponse> {
+    public async uploadImage(file: Blob, filename: string, accessToken: string, appId?: string): Promise<WechatUploadResponse> {
         let hash: string | undefined;
         if (this.uploadCacheStore) {
             const arrayBuffer = await file.arrayBuffer();
             hash = await this.uploadCacheStore.calcHash(arrayBuffer);
-            const cached = await this.uploadCacheStore.get(hash);
+            const cacheKey = appId ? `${hash}:${appId}` : hash;
+            const cached = await this.uploadCacheStore.get(cacheKey);
             if (cached) {
                 return {
                     media_id: cached.media_id,
@@ -66,7 +67,8 @@ export class WechatPublisher {
         }
         const data = await this.uploadMaterial("image", file, filename, accessToken);
         if (this.uploadCacheStore && hash) {
-            await this.uploadCacheStore.set(hash, data.media_id, data.url);
+            const cacheKey = appId ? `${hash}:${appId}` : hash;
+            await this.uploadCacheStore.set(cacheKey, data.media_id, data.url);
         }
 
         return data;


### PR DESCRIPTION
## Summary

`WechatPublisher.uploadImage()` caches uploaded images by file content hash (md5). However, WeChat `media_id` is bound to a specific `appId`. When the same image is published to a different account, the cached `media_id` from the first account is returned, causing WeChat API error **40007 (invalid media_id)**.

## Root Cause

In `src/publish.ts`:
```ts
hash = await this.uploadCacheStore.calcHash(arrayBuffer);
const cached = await this.uploadCacheStore.get(hash);  // same hash → old media_id
```

The cache key (`md5 of file content`) does not distinguish between different accounts.

## Fix

Include `appId` in the cache key so uploads are cached per account:

```ts
const cacheKey = appId ? `${hash}:${appId}` : hash;
const cached = await this.uploadCacheStore.get(cacheKey);
```

- `WechatPublisher.uploadImage()` gains an optional `appId` parameter
- `uploadImage()` and `uploadImages()` in `src/node/publish.ts` pass `appId` through the call chain
- Backward compatible: when `appId` is not provided, the old hash-only key is used

## Reproduction

```
1. Publish article with cover image to Account A → succeeds
2. Publish same article (same cover) to Account B → fails with:
   "40007: invalid media_id"
```

## Testing

Verified on a live server with two WeChat MP accounts:
- Account A publish → success
- Account B publish (same cover image) → previously failed with 40007, now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)