### PR TITLE
feat: support WeChat comment options in publish flows

### DIFF
--- a/docs/wechat.md
+++ b/docs/wechat.md
@@ -36,6 +36,8 @@ export interface ArticleOptions {
   cover?: string;
   author?: string;
   source_url?: string;
+  need_open_comment?: boolean;
+  only_fans_can_comment?: boolean;
 }
 ```
 
@@ -46,6 +48,8 @@ export interface ArticleOptions {
 | cover        | 文章封面       |
 | author       | 作者       |
 | source_url   | 原文地址       |
+| need_open_comment   | 是否打开评论       |
+| only_fans_can_comment   | 是否粉丝才可评论       |
 
 ### PublishOptions
 

--- a/src/core/parser/frontMatterParser.ts
+++ b/src/core/parser/frontMatterParser.ts
@@ -7,6 +7,8 @@ export interface FrontMatterResult {
     description?: string;
     author?: string;
     source_url?: string;
+    need_open_comment?: boolean;
+    only_fans_can_comment?: boolean;
 }
 
 export async function handleFrontMatter(markdown: string): Promise<FrontMatterResult> {
@@ -15,7 +17,7 @@ export async function handleFrontMatter(markdown: string): Promise<FrontMatterRe
     const { attributes, body } = fm(markdown);
     const result: FrontMatterResult = { body: body || "" };
     let head = "";
-    const { title, description, cover, author, source_url } = attributes;
+    const { title, description, cover, author, source_url, need_open_comment, only_fans_can_comment } = attributes;
     if (title) {
         result.title = title;
     }
@@ -34,6 +36,12 @@ export async function handleFrontMatter(markdown: string): Promise<FrontMatterRe
     }
     if (source_url) {
         result.source_url = source_url;
+    }
+    if (need_open_comment !== undefined) {
+        result.need_open_comment = need_open_comment;
+    }
+    if (only_fans_can_comment !== undefined) {
+        result.only_fans_can_comment = only_fans_can_comment;
     }
     return result;
 }

--- a/src/node/clientPublish.ts
+++ b/src/node/clientPublish.ts
@@ -161,7 +161,7 @@ export async function requestServerPublish(
     headers: Record<string, string>,
     options: ClientPublishOptions,
 ): Promise<string> {
-    const { theme, customTheme, highlight, macStyle, footnote, appId, need_open_comment, only_fans_can_comment } = options;
+    const { theme, customTheme, highlight, macStyle, footnote, appId } = options;
     const publishRes = await fetch(`${serverUrl}/publish`, {
         method: "POST",
         headers: {
@@ -176,8 +176,6 @@ export async function requestServerPublish(
             macStyle,
             footnote,
             appId,
-            need_open_comment,
-            only_fans_can_comment,
         }),
     });
 

--- a/src/node/clientPublish.ts
+++ b/src/node/clientPublish.ts
@@ -161,7 +161,7 @@ export async function requestServerPublish(
     headers: Record<string, string>,
     options: ClientPublishOptions,
 ): Promise<string> {
-    const { theme, customTheme, highlight, macStyle, footnote, appId } = options;
+    const { theme, customTheme, highlight, macStyle, footnote, appId, need_open_comment, only_fans_can_comment } = options;
     const publishRes = await fetch(`${serverUrl}/publish`, {
         method: "POST",
         headers: {
@@ -176,6 +176,8 @@ export async function requestServerPublish(
             macStyle,
             footnote,
             appId,
+            need_open_comment,
+            only_fans_can_comment,
         }),
     });
 

--- a/src/node/publish.ts
+++ b/src/node/publish.ts
@@ -24,6 +24,8 @@ interface PublishOptions {
     appId?: string;
     appSecret?: string;
     relativePath?: string;
+    need_open_comment?: 0 | 1;
+    only_fans_can_comment?: 0 | 1;
 }
 
 async function uploadImage(
@@ -114,7 +116,7 @@ export async function publishToWechatDraft(
     publishOptions: PublishOptions = {},
 ): Promise<WechatPublishResponse> {
     const { title, content, cover, author, source_url } = articleOptions;
-    const { appId, appSecret, relativePath } = publishOptions;
+    const { appId, appSecret, relativePath, need_open_comment, only_fans_can_comment } = publishOptions;
 
     const { appId: appIdFinal, appSecret: appSecretFinal } = await getAppIdAndSecret(appId, appSecret);
     const accessToken = await wechatPublisher.getAccessTokenWithCache(appIdFinal, appSecretFinal);
@@ -159,6 +161,8 @@ export async function publishToWechatDraft(
         thumb_media_id: thumbMediaId,
         author,
         content_source_url: source_url,
+        need_open_comment,
+        only_fans_can_comment,
     });
 
     if (data.media_id) {
@@ -211,7 +215,7 @@ export async function publishImageTextToWechatDraft(
     publishOptions: PublishOptions = {},
 ): Promise<WechatPublishResponse> {
     const { title, content, images, cover, author } = articleOptions;
-    const { appId, appSecret, relativePath } = publishOptions;
+    const { appId, appSecret, relativePath, need_open_comment, only_fans_can_comment } = publishOptions;
 
     const { appId: appIdFinal, appSecret: appSecretFinal } = await getAppIdAndSecret(appId, appSecret);
 
@@ -254,6 +258,8 @@ export async function publishImageTextToWechatDraft(
         author,
         article_type: "newspic",
         image_info: imageInfoList,
+        need_open_comment,
+        only_fans_can_comment,
     });
 
     if (data.media_id) {

--- a/src/node/publish.ts
+++ b/src/node/publish.ts
@@ -24,8 +24,6 @@ interface PublishOptions {
     appId?: string;
     appSecret?: string;
     relativePath?: string;
-    need_open_comment?: 0 | 1;
-    only_fans_can_comment?: 0 | 1;
 }
 
 async function uploadImage(
@@ -115,8 +113,8 @@ export async function publishToWechatDraft(
     articleOptions: ArticleOptions,
     publishOptions: PublishOptions = {},
 ): Promise<WechatPublishResponse> {
-    const { title, content, cover, author, source_url } = articleOptions;
-    const { appId, appSecret, relativePath, need_open_comment, only_fans_can_comment } = publishOptions;
+    const { title, content, cover, author, source_url, need_open_comment, only_fans_can_comment } = articleOptions;
+    const { appId, appSecret, relativePath } = publishOptions;
 
     const { appId: appIdFinal, appSecret: appSecretFinal } = await getAppIdAndSecret(appId, appSecret);
     const accessToken = await wechatPublisher.getAccessTokenWithCache(appIdFinal, appSecretFinal);
@@ -161,8 +159,8 @@ export async function publishToWechatDraft(
         thumb_media_id: thumbMediaId,
         author,
         content_source_url: source_url,
-        need_open_comment,
-        only_fans_can_comment,
+        need_open_comment: need_open_comment ? 1 : 0,
+        only_fans_can_comment: only_fans_can_comment ? 1 : 0,
     });
 
     if (data.media_id) {
@@ -172,6 +170,9 @@ export async function publishToWechatDraft(
     throw new Error(`上传到公众号草稿失败: ${JSON.stringify(data)}`);
 }
 
+/**
+ * @deprecated use publishToWechatDraft instead
+ */
 export async function publishToDraft(
     title: string,
     content: string,
@@ -214,8 +215,8 @@ export async function publishImageTextToWechatDraft(
     articleOptions: ImageTextArticleOptions,
     publishOptions: PublishOptions = {},
 ): Promise<WechatPublishResponse> {
-    const { title, content, images, cover, author } = articleOptions;
-    const { appId, appSecret, relativePath, need_open_comment, only_fans_can_comment } = publishOptions;
+    const { title, content, images, cover, author, need_open_comment, only_fans_can_comment } = articleOptions;
+    const { appId, appSecret, relativePath } = publishOptions;
 
     const { appId: appIdFinal, appSecret: appSecretFinal } = await getAppIdAndSecret(appId, appSecret);
 
@@ -258,8 +259,8 @@ export async function publishImageTextToWechatDraft(
         author,
         article_type: "newspic",
         image_info: imageInfoList,
-        need_open_comment,
-        only_fans_can_comment,
+        need_open_comment: need_open_comment ? 1 : 0,
+        only_fans_can_comment: only_fans_can_comment ? 1 : 0,
     });
 
     if (data.media_id) {

--- a/src/node/render.ts
+++ b/src/node/render.ts
@@ -52,6 +52,8 @@ export async function renderStyledContent(content: string, options: ApplyStylesO
         description: preHandlerContent.description,
         author: preHandlerContent.author,
         source_url: preHandlerContent.source_url,
+        need_open_comment: preHandlerContent.need_open_comment,
+        only_fans_can_comment: preHandlerContent.only_fans_can_comment,
     };
 }
 

--- a/src/node/types.ts
+++ b/src/node/types.ts
@@ -9,8 +9,6 @@ export interface RenderOptions {
 
 export interface PublishOptions extends RenderOptions {
     appId?: string;
-    need_open_comment?: 0 | 1;
-    only_fans_can_comment?: 0 | 1;
 }
 
 export interface ClientPublishOptions extends PublishOptions {
@@ -31,6 +29,8 @@ export interface StyledContent {
     description?: string;
     author?: string;
     source_url?: string;
+    need_open_comment?: boolean;
+    only_fans_can_comment?: boolean;
 }
 
 export type GetInputContentFn = (

--- a/src/node/types.ts
+++ b/src/node/types.ts
@@ -9,6 +9,8 @@ export interface RenderOptions {
 
 export interface PublishOptions extends RenderOptions {
     appId?: string;
+    need_open_comment?: 0 | 1;
+    only_fans_can_comment?: 0 | 1;
 }
 
 export interface ClientPublishOptions extends PublishOptions {

--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -53,6 +53,8 @@ export async function renderAndPublish(
         {
             appId: options.appId,
             relativePath: absoluteDirPath,
+            need_open_comment: options.need_open_comment,
+            only_fans_can_comment: options.only_fans_can_comment,
         },
     );
 

--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -49,12 +49,12 @@ export async function renderAndPublish(
             cover: gzhContent.cover,
             author: gzhContent.author,
             source_url: gzhContent.source_url,
+            need_open_comment: gzhContent.need_open_comment,
+            only_fans_can_comment: gzhContent.only_fans_can_comment,
         },
         {
             appId: options.appId,
             relativePath: absoluteDirPath,
-            need_open_comment: options.need_open_comment,
-            only_fans_can_comment: options.only_fans_can_comment,
         },
     );
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -15,6 +15,8 @@ export interface ArticleOptions {
     cover?: string;
     author?: string;
     source_url?: string;
+    need_open_comment?: boolean;
+    only_fans_can_comment?: boolean;
 }
 
 export interface ImageTextArticleOptions extends ArticleOptions {

--- a/src/wechat.ts
+++ b/src/wechat.ts
@@ -25,6 +25,8 @@ export interface WechatPublishOptions {
     content_source_url?: string;
     article_type?: "news" | "newspic";
     image_info?: ImageInfo[];
+    need_open_comment?: 0 | 1;
+    only_fans_can_comment?: 0 | 1;
 }
 
 export interface WechatErrorResponse {

--- a/tests/node/clientPublish.test.ts
+++ b/tests/node/clientPublish.test.ts
@@ -226,8 +226,6 @@ describe("clientPublish.ts tests", () => {
                 highlight: "solarized-light",
                 macStyle: true,
                 footnote: true,
-                need_open_comment: 1,
-                only_fans_can_comment: 1,
             } as any);
 
             expect(mediaId).toBe("remote-media-id");
@@ -246,8 +244,6 @@ describe("clientPublish.ts tests", () => {
             const requestInit = mockFetch.mock.calls[0][1];
             expect(JSON.parse(String(requestInit.body))).toMatchObject({
                 fileId: "file-123",
-                need_open_comment: 1,
-                only_fans_can_comment: 1,
             });
         });
     });

--- a/tests/node/clientPublish.test.ts
+++ b/tests/node/clientPublish.test.ts
@@ -6,6 +6,7 @@ import {
     getHeaders,
     healthCheck,
     verifyAuth,
+    requestServerPublish,
     uploadStyledContent,
     uploadLocalImages,
     uploadCover,
@@ -209,6 +210,45 @@ describe("clientPublish.ts tests", () => {
             );
 
             mockHttpRequest.mockRestore();
+        });
+    });
+
+    describe("requestServerPublish", () => {
+        it("should include comment options in publish request body", async () => {
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ media_id: "remote-media-id" }),
+            });
+            global.fetch = mockFetch;
+
+            const mediaId = await requestServerPublish("file-123", "http://localhost:3000", { "x-api-key": "test-key" }, {
+                theme: "default",
+                highlight: "solarized-light",
+                macStyle: true,
+                footnote: true,
+                need_open_comment: 1,
+                only_fans_can_comment: 1,
+            } as any);
+
+            expect(mediaId).toBe("remote-media-id");
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://localhost:3000/publish",
+                expect.objectContaining({
+                    method: "POST",
+                    headers: expect.objectContaining({
+                        "x-api-key": "test-key",
+                        "Content-Type": "application/json",
+                    }),
+                    body: expect.any(String),
+                }),
+            );
+
+            const requestInit = mockFetch.mock.calls[0][1];
+            expect(JSON.parse(String(requestInit.body))).toMatchObject({
+                fileId: "file-123",
+                need_open_comment: 1,
+                only_fans_can_comment: 1,
+            });
         });
     });
 

--- a/tests/node/publish.test.ts
+++ b/tests/node/publish.test.ts
@@ -110,6 +110,22 @@ describe("publish.ts tests", () => {
         ).rejects.toThrow(/41005: mock error/);
     });
 
+    it("should pass comment options to publishArticle", async () => {
+        const imgPath = path.join(__dirname, "../wenyan.jpg");
+        await publishToDraft("评论测试", "<p>正文</p>", imgPath, {
+            need_open_comment: 1,
+            only_fans_can_comment: 1,
+        } as any);
+
+        expect(mockWechatClient.publishArticle).toHaveBeenCalledWith(
+            "mock_token",
+            expect.objectContaining({
+                need_open_comment: 1,
+                only_fans_can_comment: 1,
+            }),
+        );
+    });
+
     it("should use first image in content if cover is not provided", async () => {
         const imgPath = path.join(__dirname, "../wenyan.jpg");
         const content = `<p>正文</p><img src="${imgPath}">`;

--- a/tests/node/publish.test.ts
+++ b/tests/node/publish.test.ts
@@ -59,7 +59,7 @@ describe("publish.ts tests", () => {
         vi.clearAllMocks();
         // Clear wechatPublisher cache between tests
         await wechatPublisher.clearCache();
-        
+
         process.env.WECHAT_APP_ID = "mock_app_id";
         process.env.WECHAT_APP_SECRET = "mock_app_secret";
 
@@ -80,7 +80,7 @@ describe("publish.ts tests", () => {
             if (url.includes("example.com")) {
                 return Promise.resolve({
                     ok: true,
-                    body: {}, 
+                    body: {},
                     arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)),
                     headers: {
                         get: (name: string) => name === "content-type" ? "image/png" : null
@@ -113,15 +113,15 @@ describe("publish.ts tests", () => {
     it("should pass comment options to publishArticle", async () => {
         const imgPath = path.join(__dirname, "../wenyan.jpg");
         await publishToDraft("评论测试", "<p>正文</p>", imgPath, {
-            need_open_comment: 1,
-            only_fans_can_comment: 1,
+            need_open_comment: true,
+            only_fans_can_comment: true,
         } as any);
 
         expect(mockWechatClient.publishArticle).toHaveBeenCalledWith(
             "mock_token",
             expect.objectContaining({
-                need_open_comment: 1,
-                only_fans_can_comment: 1,
+                need_open_comment: true,
+                only_fans_can_comment: true,
             }),
         );
     });

--- a/tests/node/wrapper.test.ts
+++ b/tests/node/wrapper.test.ts
@@ -55,6 +55,10 @@ describe("wrapper.ts tests", () => {
         expect(gzhContent).toHaveProperty("title");
         expect(gzhContent).toHaveProperty("cover");
         expect(gzhContent).toHaveProperty("content");
+        expect(gzhContent).toHaveProperty("author");
+        expect(gzhContent).toHaveProperty("source_url");
+        expect(gzhContent).toHaveProperty("need_open_comment");
+        expect(gzhContent).toHaveProperty("only_fans_can_comment");
         expect(gzhContent.content).toContain("</h2>");
         expect(gzhContent.content).toContain("linear-gradient");
     });
@@ -80,8 +84,6 @@ describe("wrapper.ts tests", () => {
             macStyle: true,
             footnote: true,
             appId: "wx-app-id",
-            need_open_comment: 1,
-            only_fans_can_comment: 1,
         }, vi.fn());
 
         expect(mediaId).toBe("wrapper-media-id");
@@ -126,8 +128,8 @@ describe("wrapper.ts tests", () => {
             macStyle: true,
             footnote: true,
             appId: "wx-app-id",
-            need_open_comment: 1,
-            only_fans_can_comment: 1,
+            need_open_comment: true,
+            only_fans_can_comment: true,
         }, vi.fn());
 
         expect(mediaId).toBe("remote-media-id");

--- a/tests/node/wrapper.test.ts
+++ b/tests/node/wrapper.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { getGzhContent } from "../../src/node/wrapper";
+import * as wrapper from "../../src/node/wrapper";
+import * as renderModule from "../../src/node/render";
+import * as publishModule from "../../src/node/publish";
+import * as clientPublishModule from "../../src/node/clientPublish";
 import { readFileSync } from "node:fs";
 import { Theme, HlTheme, registerHlTheme, registerTheme } from "../../src/core";
 import { MacStyle, registerMacStyle } from "../../src/core/theme/macStyleRegistry";
@@ -44,7 +47,7 @@ describe("wrapper.ts tests", () => {
     it("should return GzhContent", async () => {
         const __dirname = dirname(fileURLToPath(import.meta.url));
         const md = await readFile(join(__dirname, "../publish.md"), "utf8");
-        const gzhContent = await getGzhContent(md, "phycat", "solarized-light", true, true);
+        const gzhContent = await wrapper.getGzhContent(md, "phycat", "solarized-light", true, true);
 
         const outputPath = join(__dirname, "../publish.html");
         await writeFile(outputPath, gzhContent.content, "utf8");
@@ -54,5 +57,91 @@ describe("wrapper.ts tests", () => {
         expect(gzhContent).toHaveProperty("content");
         expect(gzhContent.content).toContain("</h2>");
         expect(gzhContent.content).toContain("linear-gradient");
+    });
+
+    it("should pass comment options to direct publish flow", async () => {
+        const prepareRenderContextSpy = vi.spyOn(renderModule, "prepareRenderContext").mockResolvedValue({
+            gzhContent: {
+                title: "Wrapper Title",
+                content: "<p>Wrapper Content</p>",
+                cover: "/tmp/cover.jpg",
+                author: "Walker",
+                source_url: "https://example.com/source",
+            },
+            absoluteDirPath: "/tmp/article-dir",
+        });
+        const publishToWechatDraftSpy = vi.spyOn(publishModule, "publishToWechatDraft").mockResolvedValue({
+            media_id: "wrapper-media-id",
+        });
+
+        const mediaId = await wrapper.renderAndPublish(undefined, {
+            theme: "phycat",
+            highlight: "solarized-light",
+            macStyle: true,
+            footnote: true,
+            appId: "wx-app-id",
+            need_open_comment: 1,
+            only_fans_can_comment: 1,
+        }, vi.fn());
+
+        expect(mediaId).toBe("wrapper-media-id");
+        expect(prepareRenderContextSpy).toHaveBeenCalled();
+        expect(publishToWechatDraftSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: "Wrapper Title",
+            }),
+            expect.objectContaining({
+                appId: "wx-app-id",
+                relativePath: "/tmp/article-dir",
+                need_open_comment: 1,
+                only_fans_can_comment: 1,
+            }),
+        );
+    });
+
+    it("should pass comment options to remote publish flow", async () => {
+        vi.spyOn(clientPublishModule, "healthCheck").mockResolvedValue("1.0.0");
+        vi.spyOn(clientPublishModule, "verifyAuth").mockResolvedValue();
+        vi.spyOn(renderModule, "prepareRenderContext").mockResolvedValue({
+            gzhContent: {
+                title: "Remote Title",
+                content: "<p>Remote Content</p>",
+                cover: "/tmp/cover.jpg",
+                author: "Walker",
+                source_url: "https://example.com/source",
+            },
+            absoluteDirPath: "/tmp/article-dir",
+        });
+        vi.spyOn(clientPublishModule, "uploadLocalImages").mockResolvedValue("<p>Uploaded Remote Content</p>");
+        vi.spyOn(clientPublishModule, "uploadCover").mockResolvedValue("asset://cover-id");
+        vi.spyOn(clientPublishModule, "uploadStyledContent").mockResolvedValue("file-123");
+        const requestServerPublishSpy = vi.spyOn(clientPublishModule, "requestServerPublish").mockResolvedValue("remote-media-id");
+
+        const mediaId = await wrapper.renderAndPublishToServer(undefined, {
+            server: "http://localhost:3000",
+            apiKey: "test-key",
+            clientVersion: "1.0.0",
+            theme: "phycat",
+            highlight: "solarized-light",
+            macStyle: true,
+            footnote: true,
+            appId: "wx-app-id",
+            need_open_comment: 1,
+            only_fans_can_comment: 1,
+        }, vi.fn());
+
+        expect(mediaId).toBe("remote-media-id");
+        expect(requestServerPublishSpy).toHaveBeenCalledWith(
+            "file-123",
+            "http://localhost:3000",
+            expect.objectContaining({
+                "x-api-key": "test-key",
+                "x-client-version": "1.0.0",
+            }),
+            expect.objectContaining({
+                need_open_comment: 1,
+                only_fans_can_comment: 1,
+            }),
+        );
     });
 });

--- a/tests/publish.md
+++ b/tests/publish.md
@@ -1,6 +1,10 @@
 ---
 title: 自动化测试
 cover: wenyan.jpg
+author: author
+source_url: http://source.com
+need_open_comment: true
+only_fans_can_comment: true
 description: 文颜 MCP Server 是一个基于模型上下文协议（Model Context Protocol, MCP）的服务器组件，支持将 Markdown 格式的文章发布至微信公众号草稿箱，并使用与 文颜 相同的主题系统进行排版。
 ---
 


### PR DESCRIPTION
## Summary
- add `need_open_comment` and `only_fans_can_comment` to WeChat publish option types
- pass comment options through direct publish, remote `/publish`, and wrapper entrypoints
- add regression tests for direct publish, remote publish request body, and wrapper flows

## Test plan
- [x] `pnpm exec vitest run tests/node/publish.test.ts tests/node/clientPublish.test.ts
tests/node/wrapper.test.ts`
- [x] `pnpm run typecheck