### PR TITLE
feat: 支持小绿书 server 模式客户端发布

### DIFF
--- a/src/node/clientPublish.ts
+++ b/src/node/clientPublish.ts
@@ -230,3 +230,63 @@ export async function uploadCover(
     }
     return cover;
 }
+
+/**
+ * 上传本地图片文件到服务器，返回 fileId
+ */
+export async function uploadImageFile(
+    imagePath: string,
+    serverUrl: string,
+    headers: Record<string, string>,
+): Promise<string> {
+    const fileBuffer = await readBinaryFile(imagePath);
+    const filename = path.basename(imagePath);
+    const ext = path.extname(filename).toLowerCase();
+    const mimeTypes: Record<string, string> = {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+        ".svg": "image/svg+xml",
+    };
+    const mimeType = mimeTypes[ext] || "application/octet-stream";
+    const uploadData: any = await chunkedUpload(serverUrl, headers, fileBuffer, filename, mimeType);
+    if (!uploadData.success) {
+        throw new Error(`上传图片失败 (${filename}): ${uploadData.error || uploadData.desc}`);
+    }
+    return uploadData.data.fileId;
+}
+
+/**
+ * 请求服务器发布小绿书（图片消息）
+ */
+export async function requestServerPublishImage(
+    imageFileIds: string[],
+    serverUrl: string,
+    headers: Record<string, string>,
+    options: { appId?: string; coverFileId?: string; content?: string; author?: string },
+): Promise<string> {
+    const publishRes = await fetch(`${serverUrl}/publish-image`, {
+        method: "POST",
+        headers: {
+            ...headers,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            imageFileIds,
+            coverFileId: options.coverFileId,
+            content: options.content,
+            author: options.author,
+            appId: options.appId,
+        }),
+    });
+
+    const publishData: any = await publishRes.json();
+
+    if (!publishRes.ok || publishData.code === -1) {
+        throw new Error(`Remote Publish Failed: ${publishData.desc || publishRes.statusText}`);
+    }
+
+    return publishData.media_id;
+}

--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -3,7 +3,9 @@ import {
     getServerUrl,
     healthCheck,
     requestServerPublish,
+    requestServerPublishImage,
     uploadCover,
+    uploadImageFile,
     uploadLocalImages,
     uploadStyledContent,
     verifyAuth,
@@ -101,6 +103,49 @@ export async function renderAndPublishToServer(
     // 5. 此时服务器上有渲染后的 HTML 文件、发布元数据、图片，调用服务端接口发布文章
     // ==========================================
     return await requestServerPublish(mdFileId, serverUrl, headers, options);
+}
+
+export async function publishImageTextToServer(
+    images: string[],
+    options: { server: string; apiKey?: string; clientVersion?: string; appId?: string; content?: string; author?: string; cover?: string },
+): Promise<string> {
+    const serverUrl = options.server.replace(/\/$/, "");
+    const headers: Record<string, string> = {};
+    if (options.clientVersion) headers["x-client-version"] = options.clientVersion;
+    if (options.apiKey) headers["x-api-key"] = options.apiKey;
+
+    // ==========================================
+    // 0. 连通性与鉴权测试
+    // ==========================================
+    await healthCheck(serverUrl);
+    await verifyAuth(serverUrl, headers);
+
+    // ==========================================
+    // 1. 上传所有图片文件到服务器
+    // ==========================================
+    const imageFileIds: string[] = [];
+    for (const imagePath of images) {
+        const fileId = await uploadImageFile(imagePath, serverUrl, headers);
+        imageFileIds.push(fileId);
+    }
+
+    // ==========================================
+    // 2. 处理封面图（如果指定且为本地文件）
+    // ==========================================
+    let coverFileId: string | undefined;
+    if (options.cover) {
+        coverFileId = await uploadImageFile(options.cover, serverUrl, headers);
+    }
+
+    // ==========================================
+    // 3. 请求服务器发布小绿书
+    // ==========================================
+    return await requestServerPublishImage(imageFileIds, serverUrl, headers, {
+        appId: options.appId,
+        coverFileId,
+        content: options.content,
+        author: options.author,
+    });
 }
 
 export * from "./configStore.js";


### PR DESCRIPTION
## Summary
- 新增 `uploadImageFile()` / `requestServerPublishImage()` 客户端函数，用于将本地图片上传到服务器并请求发布小绿书
- 新增 `publishImageTextToServer()` 编排函数，完成 health check → 上传图片 → 请求发布的完整 server 模式流程
- 配合 wenyan-cli PR [#27](https://github.com/caol64/wenyan-cli/pull/27) 实现小绿书的 server 模式支持

## Test plan
- [ ] `pnpm typecheck` 通过
- [ ] 配合 wenyan-cli 的 `wenyan publish -f post.md --type newspic --server <url>` 命令进行端到端测试