### PR TITLE
fix: 支持图片 URL 中包含空格

### DIFF
--- a/src/core/parser/markedParser.ts
+++ b/src/core/parser/markedParser.ts
@@ -112,8 +112,19 @@ export function createMarkedClient() {
          */
         async parse(markdown: string): Promise<string> {
             await configure();
-            // marked.parse 返回可能是 string | Promise<string>，这里强制转为 Promise 处理
-            return md.parse(markdown) as Promise<string>;
+            // Preprocess: wrap image URLs containing spaces in angle brackets
+            // so marked doesn't truncate them per CommonMark spec.
+            // Transforms ![alt](path with spaces.png) into ![alt](<path with spaces.png>)
+            const processed = markdown.replace(
+                /(!\[[^\]]*\]\()([^)\n"']+)(\))/g,
+                (_match, prefix, url, suffix) => {
+                    if (url.includes(' ')) {
+                        return `${prefix}<${url}>${suffix}`;
+                    }
+                    return _match;
+                }
+            );
+            return md.parse(processed) as Promise<string>;
         },
     };
 }

--- a/src/core/parser/markedParser.ts
+++ b/src/core/parser/markedParser.ts
@@ -26,9 +26,33 @@ export function createMarkedClient() {
 
             md.use(highlightExtension);
 
-            // ----------- 2. 自定义图片语法扩展 ![](){...} -----------
+            // ----------- 2. 自定义语法扩展 -----------
             md.use({
                 extensions: [
+                    // 宽松 link/image tokenizer，允许 URL 中包含空格（不要求用 <> 包裹）
+                    {
+                        name: "looseLink",
+                        level: "inline",
+                        start(src) {
+                            return src.match(/!?\[/)?.index;
+                        },
+                        tokenizer(src) {
+                            const rule = /^(!?)\[([^\]]*)\]\(([^)]+)\)/;
+                            const match = rule.exec(src);
+                            if (!match) return;
+
+                            const isImage = !!match[1];
+
+                            return {
+                                type: isImage ? "image" : "link",
+                                raw: match[0],
+                                text: match[2],
+                                href: match[3],
+                                tokens: this.lexer.inlineTokens(match[2]),
+                            };
+                        },
+                    },
+                    // 自定义图片语法扩展 ![](){...}
                     {
                         name: "attributeImage",
                         level: "inline",
@@ -58,10 +82,12 @@ export function createMarkedClient() {
                             const styleStr = Array.from(attrs)
                                 .map(([k, v]) => (/^\d+$/.test(v) ? `${k}:${v}px` : `${k}:${v}`))
                                 .join("; ");
+                            const href = normalizeHref(token.href);
 
-                            return `<img src="${token.href}" alt="${token.text || ""}" title="${token.text || ""}" style="${styleStr}">`;
+                            return `<img src="${href}" alt="${token.text || ""}" title="${token.text || ""}" style="${styleStr}">`;
                         },
                     },
+
                 ],
             });
 
@@ -97,7 +123,13 @@ export function createMarkedClient() {
 
                     // 重写普通图片 (处理标准 Markdown 图片)
                     image(this: Renderer, token: Tokens.Image) {
-                        return `<img src="${token.href}" alt="${token.text || ""}" title="${token.title || token.text || ""}">`;
+                        const href = normalizeHref(token.href);
+                        return `<img src="${href}" alt="${token.text || ""}" title="${token.title || token.text || ""}">`;
+                    },
+
+                    link(this: Renderer, token: Tokens.Link) {
+                        const href = normalizeHref(token.href);
+                        return `<a href="${href}">${this.parser.parseInline(token.tokens)}</a>`;
                     },
                 },
             });
@@ -112,19 +144,22 @@ export function createMarkedClient() {
          */
         async parse(markdown: string): Promise<string> {
             await configure();
-            // Preprocess: wrap image URLs containing spaces in angle brackets
-            // so marked doesn't truncate them per CommonMark spec.
-            // Transforms ![alt](path with spaces.png) into ![alt](<path with spaces.png>)
-            const processed = markdown.replace(
-                /(!\[[^\]]*\]\()([^)\n"']+)(\))/g,
-                (_match, prefix, url, suffix) => {
-                    if (url.includes(' ')) {
-                        return `${prefix}<${url}>${suffix}`;
-                    }
-                    return _match;
-                }
-            );
-            return md.parse(processed) as Promise<string>;
+            // marked.parse 返回可能是 string | Promise<string>，这里强制转为 Promise 处理
+            return await md.parse(markdown);
         },
     };
+}
+
+function normalizeHref(href: string): string {
+    href = href.trim();
+    if (href.startsWith("<") && href.endsWith(">")) {
+        // 如果 href 被尖括号包裹，去掉尖括号
+        href = href.slice(1, -1);
+    }
+
+    try {
+        return encodeURI(href);
+    } catch {
+        return href;
+    }
 }

--- a/tests/core/parser.test.ts
+++ b/tests/core/parser.test.ts
@@ -46,4 +46,23 @@ describe("createWenyanCore", async () => {
         expect(result).toContain('style="x:100px"');
 
     });
+
+    it("should render image with spaces in URL", async () => {
+        const md = "![](../0.asset/media/Pasted image 20250712230833.png)";
+        const result = await instance.renderMarkdown(md);
+        expect(result).toContain('src="../0.asset/media/Pasted image 20250712230833.png"');
+    });
+
+    it("should render image with spaces and alt text", async () => {
+        const md = "![diagram](D:/Notes/media/my image.png)";
+        const result = await instance.renderMarkdown(md);
+        expect(result).toContain('src="D:/Notes/media/my image.png"');
+        expect(result).toContain('alt="diagram"');
+    });
+
+    it("should not break image URLs without spaces", async () => {
+        const md = "![](../0.asset/media/autosar-arch-overview.png)";
+        const result = await instance.renderMarkdown(md);
+        expect(result).toContain('src="../0.asset/media/autosar-arch-overview.png"');
+    });
 });

--- a/tests/core/parser.test.ts
+++ b/tests/core/parser.test.ts
@@ -32,10 +32,9 @@ describe("createWenyanCore", async () => {
 
         // 5. 验证代码内容是否保留
         expect(result).toContain("sys");
-
     });
 
-    it("should render markdown with image", async () => {
+    it("should render markdown with image and custom attributes", async () => {
         const md = "![](C:/Users/lei/Downloads/1_0D7dkNntY-hlvNXAHzHr2g.jpg){x=100}";
         const result = await instance.renderMarkdown(md);
 
@@ -44,19 +43,25 @@ describe("createWenyanCore", async () => {
 
         // 验证自定义属性是否正确渲染
         expect(result).toContain('style="x:100px"');
+    });
 
+    it("should render markdown with image and custom attributes with spaces in URL", async () => {
+        const md = "![](C:/Users/lei/Downloads/1_0D7dkNntY-hlvNXA HzHr2g.jpg){x=100}";
+        const result = await instance.renderMarkdown(md);
+        expect(result).toContain('src="C:/Users/lei/Downloads/1_0D7dkNntY-hlvNXA%20HzHr2g.jpg');
+        expect(result).toContain('style="x:100px"');
     });
 
     it("should render image with spaces in URL", async () => {
         const md = "![](../0.asset/media/Pasted image 20250712230833.png)";
         const result = await instance.renderMarkdown(md);
-        expect(result).toContain('src="../0.asset/media/Pasted image 20250712230833.png"');
+        expect(result).toContain('src="../0.asset/media/Pasted%20image%2020250712230833.png"');
     });
 
     it("should render image with spaces and alt text", async () => {
         const md = "![diagram](D:/Notes/media/my image.png)";
         const result = await instance.renderMarkdown(md);
-        expect(result).toContain('src="D:/Notes/media/my image.png"');
+        expect(result).toContain('src="D:/Notes/media/my%20image.png"');
         expect(result).toContain('alt="diagram"');
     });
 
@@ -64,5 +69,23 @@ describe("createWenyanCore", async () => {
         const md = "![](../0.asset/media/autosar-arch-overview.png)";
         const result = await instance.renderMarkdown(md);
         expect(result).toContain('src="../0.asset/media/autosar-arch-overview.png"');
+    });
+
+    it("should render link with spaces in URL", async () => {
+        const md = "[link](../0.asset/media/Pasted image 20250712230833.md)";
+        const result = await instance.renderMarkdown(md);
+        expect(result).toContain('href="../0.asset/media/Pasted%20image%2020250712230833.md"');
+    });
+
+    it("should render link", async () => {
+        const md = "[link](../0.asset/media/Pasted_image_20250712230833.md)";
+        const result = await instance.renderMarkdown(md);
+        expect(result).toContain('href="../0.asset/media/Pasted_image_20250712230833.md"');
+    });
+
+    it("should render link with angle brackets and spaces in URL", async () => {
+        const md = "[link](<../0.asset/media/Pasted image 20250712230833.md>)";
+        const result = await instance.renderMarkdown(md);
+        expect(result).toContain('href="../0.asset/media/Pasted%20image%2020250712230833.md"');
     });
 });


### PR DESCRIPTION
## 问题

`marked` 库遵循 CommonMark 规范，会将裸 URL 在第一个空格处截断。当图片文件名包含空格时（例如 Obsidian 粘贴图片的默认命名 `Pasted image 20250712xxx.png`），生成的 `<img>` 标签 `src` 属性不完整，导致图片无法上传到微信 CDN。

## 修复方案

在 `markedParser.ts` 的 `parse()` 方法中增加预处理步骤：检测图片 URL 中是否包含空格，如果包含则自动用尖括号包裹（CommonMark 语法 `![alt](<path with spaces.png>)`），使 `marked` 能正确解析完整 URL。

## 变更

- `src/core/parser/markedParser.ts`：在 `parse()` 中增加预处理正则，将含空格的图片 URL 包裹在尖括号中
- `tests/parser.test.ts`：新增 3 个测试用例覆盖空格 URL 场景

## 测试

```
✓ should render image with spaces in URL
✓ should render image with spaces and alt text  
✓ should not break image URLs without spaces
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)