### PR TITLE
feat: handle type:image frontmatter to auto-extract image_list

### DIFF
--- a/src/core/parser/frontMatterParser.ts
+++ b/src/core/parser/frontMatterParser.ts
@@ -12,13 +12,40 @@ export interface FrontMatterResult {
     image_list?: string[];
 }
 
+/**
+ * 从正文中提取图片路径并清理图片引用。
+ * 支持标准 Markdown 图片 ![](path) 和 Obsidian 嵌入 ![[file.png|desc]]。
+ */
+function extractAndCleanImages(body: string): { imagePaths: string[]; cleanedBody: string } {
+    const imagePaths: string[] = [];
+
+    // 提取标准 Markdown 图片路径: ![alt](path)
+    const mdImageRe = /!\[[^\]]*\]\(([^)]+)\)/g;
+    // 提取 Obsidian 嵌入图片: ![[file.png|desc]] 或 ![[file.png]]
+    const obsidianImageRe = /!\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g;
+
+    let match: RegExpExecArray | null;
+    while ((match = mdImageRe.exec(body)) !== null) {
+        imagePaths.push(match[1]);
+    }
+    while ((match = obsidianImageRe.exec(body)) !== null) {
+        imagePaths.push(match[1].trim());
+    }
+
+    const cleanedBody = body
+        .replace(/!\[[^\]]*\]\([^)]+\)\s*/g, "")
+        .replace(/!\[\[[^\]]+\]\]\s*/g, "");
+
+    return { imagePaths, cleanedBody };
+}
+
 export async function handleFrontMatter(markdown: string): Promise<FrontMatterResult> {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     const { attributes, body } = fm(markdown);
     const result: FrontMatterResult = { content: body || "" };
     let head = "";
-    const { title, description, cover, author, source_url, need_open_comment, only_fans_can_comment, image_list } = attributes;
+    const { title, description, cover, author, source_url, need_open_comment, only_fans_can_comment, image_list, type } = attributes;
     if (title) {
         result.title = title;
     }
@@ -28,9 +55,6 @@ export async function handleFrontMatter(markdown: string): Promise<FrontMatterRe
     }
     if (cover) {
         result.cover = cover;
-    }
-    if (head) {
-        result.content = head + result.content;
     }
     if (author) {
         result.author = author;
@@ -47,5 +71,18 @@ export async function handleFrontMatter(markdown: string): Promise<FrontMatterRe
     if (image_list) {
         result.image_list = image_list;
     }
+    if (head) {
+        result.content = head + result.content;
+    }
+
+    // type: image 小绿书模式：自动从正文提取图片注入 image_list，并清理正文中的图片引用
+    if (type === "image" && !image_list) {
+        const { imagePaths, cleanedBody } = extractAndCleanImages(result.content);
+        if (imagePaths.length > 0) {
+            result.image_list = imagePaths;
+            result.content = cleanedBody;
+        }
+    }
+
     return result;
 }

--- a/src/core/parser/frontMatterParser.ts
+++ b/src/core/parser/frontMatterParser.ts
@@ -10,33 +10,7 @@ export interface FrontMatterResult {
     need_open_comment?: boolean;
     only_fans_can_comment?: boolean;
     image_list?: string[];
-}
-
-/**
- * 从正文中提取图片路径并清理图片引用。
- * 支持标准 Markdown 图片 ![](path) 和 Obsidian 嵌入 ![[file.png|desc]]。
- */
-function extractAndCleanImages(body: string): { imagePaths: string[]; cleanedBody: string } {
-    const imagePaths: string[] = [];
-
-    // 提取标准 Markdown 图片路径: ![alt](path)
-    const mdImageRe = /!\[[^\]]*\]\(([^)]+)\)/g;
-    // 提取 Obsidian 嵌入图片: ![[file.png|desc]] 或 ![[file.png]]
-    const obsidianImageRe = /!\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g;
-
-    let match: RegExpExecArray | null;
-    while ((match = mdImageRe.exec(body)) !== null) {
-        imagePaths.push(match[1]);
-    }
-    while ((match = obsidianImageRe.exec(body)) !== null) {
-        imagePaths.push(match[1].trim());
-    }
-
-    const cleanedBody = body
-        .replace(/!\[[^\]]*\]\([^)]+\)\s*/g, "")
-        .replace(/!\[\[[^\]]+\]\]\s*/g, "");
-
-    return { imagePaths, cleanedBody };
+    type?: string;
 }
 
 export async function handleFrontMatter(markdown: string): Promise<FrontMatterResult> {
@@ -71,17 +45,11 @@ export async function handleFrontMatter(markdown: string): Promise<FrontMatterRe
     if (image_list) {
         result.image_list = image_list;
     }
+    if (type) {
+        result.type = type;
+    }
     if (head) {
         result.content = head + result.content;
-    }
-
-    // type: image 小绿书模式：自动从正文提取图片注入 image_list，并清理正文中的图片引用
-    if (type === "image" && !image_list) {
-        const { imagePaths, cleanedBody } = extractAndCleanImages(result.content);
-        if (imagePaths.length > 0) {
-            result.image_list = imagePaths;
-            result.content = cleanedBody;
-        }
     }
 
     return result;

--- a/src/node/render.ts
+++ b/src/node/render.ts
@@ -5,6 +5,31 @@ import { getNormalizeFilePath, readFileContent } from "./utils.js";
 import { JSDOM } from "jsdom";
 import { createNodeMermaidRenderer } from "./mermaidRenderer.js";
 
+/**
+ * 从正文中提取图片路径并清理图片引用。
+ * 支持标准 Markdown 图片 ![](path) 和 Obsidian 嵌入 ![[file.png|desc]]。
+ */
+function extractAndCleanImages(body: string): { imagePaths: string[]; cleanedBody: string } {
+    const imagePaths: string[] = [];
+
+    const mdImageRe = /!\[[^\]]*\]\(([^)]+)\)/g;
+    const obsidianImageRe = /!\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g;
+
+    let match: RegExpExecArray | null;
+    while ((match = mdImageRe.exec(body)) !== null) {
+        imagePaths.push(match[1]);
+    }
+    while ((match = obsidianImageRe.exec(body)) !== null) {
+        imagePaths.push(match[1].trim());
+    }
+
+    const cleanedBody = body
+        .replace(/!\[[^\]]*\]\([^)]+\)\s*/g, "")
+        .replace(/!\[\[[^\]]+\]\]\s*/g, "");
+
+    return { imagePaths, cleanedBody };
+}
+
 const nodeMermaidRenderer = createNodeMermaidRenderer();
 const wenyanCoreInstance = await createWenyanCore({
     mermaid: {
@@ -69,6 +94,14 @@ export async function prepareRenderContext(
 ): Promise<RenderContext> {
     const { content, absoluteDirPath } = await getInputContent(inputContent, options.file);
     const preHandlerContent = await wenyanCoreInstance.handleFrontMatter(content);
+    // type: image 小绿书模式：自动从正文提取图片注入 image_list，并清理正文中的图片引用
+    if (preHandlerContent.type === "image" && !preHandlerContent.image_list) {
+        const { imagePaths, cleanedBody } = extractAndCleanImages(preHandlerContent.content);
+        if (imagePaths.length > 0) {
+            preHandlerContent.image_list = imagePaths;
+            preHandlerContent.content = cleanedBody;
+        }
+    }
     if (preHandlerContent.image_list && preHandlerContent.image_list.length > 0) {
         // 图片文章（小绿书）不需要应用主题样式，直接返回内容
         return { gzhContent: preHandlerContent, absoluteDirPath };

--- a/tests/core/parser/frontMatter.test.ts
+++ b/tests/core/parser/frontMatter.test.ts
@@ -108,8 +108,8 @@ Content`;
         });
     });
 
-    describe("type: image transformation", () => {
-        it("should extract markdown images from body and inject image_list", async () => {
+    describe("type field passthrough", () => {
+        it("should pass through type field", async () => {
             const markdown = `---
 title: Photo Post
 type: image
@@ -118,100 +118,26 @@ Some text before.
 
 ![alt1](photo1.jpg)
 
-![alt2](photo2.png)
-
 Some text after.`;
 
             const result = await handleFrontMatter(markdown);
 
             expect(result.title).toBe("Photo Post");
-            expect(result.image_list).toEqual(["photo1.jpg", "photo2.png"]);
-            expect(result.content).not.toContain("![");
-            expect(result.content).toContain("Some text before.");
-            expect(result.content).toContain("Some text after.");
+            expect(result.type).toBe("image");
+            // handleFrontMatter 不做图片提取，正文保持原样
+            expect(result.image_list).toBeUndefined();
+            expect(result.content).toContain("![");
         });
 
-        it("should extract Obsidian embed images from body", async () => {
-            const markdown = `---
-title: Obsidian Photos
-type: image
----
-![[image1.png]]
-![[image2.jpg|description]]
-Text between images.`;
-
-            const result = await handleFrontMatter(markdown);
-
-            expect(result.image_list).toEqual(["image1.png", "image2.jpg"]);
-            expect(result.content).not.toContain("![[");
-            expect(result.content).toContain("Text between images.");
-        });
-
-        it("should extract mixed markdown and Obsidian images", async () => {
-            const markdown = `---
-title: Mixed Images
-type: image
----
-![](md.jpg)
-![[obsidian.png]]
-Text.`;
-
-            const result = await handleFrontMatter(markdown);
-
-            expect(result.image_list).toEqual(["md.jpg", "obsidian.png"]);
-        });
-
-        it("should not transform when type is not image", async () => {
+        it("should not set type when absent", async () => {
             const markdown = `---
 title: Normal Post
-type: article
 ---
-![](photo.jpg)
-Text.`;
+Just text.`;
 
             const result = await handleFrontMatter(markdown);
 
-            expect(result.image_list).toBeUndefined();
-            expect(result.content).toContain("![");
-        });
-
-        it("should not transform when image_list already exists in frontmatter", async () => {
-            const markdown = `---
-title: Manual Image List
-type: image
-image_list:
-  - custom1.jpg
-  - custom2.jpg
----
-![](photo.jpg)
-Text.`;
-
-            const result = await handleFrontMatter(markdown);
-
-            expect(result.image_list).toEqual(["custom1.jpg", "custom2.jpg"]);
-            expect(result.content).toContain("![");
-        });
-
-        it("should not transform when body has no images", async () => {
-            const markdown = `---
-title: No Images
-type: image
----
-Just text, no images.`;
-
-            const result = await handleFrontMatter(markdown);
-
-            expect(result.image_list).toBeUndefined();
-            expect(result.content).toContain("Just text, no images.");
-        });
-
-        it("should not transform when frontmatter is absent", async () => {
-            const markdown = "![](photo.jpg)\nJust text.";
-
-            const result = await handleFrontMatter(markdown);
-
-            expect(result.image_list).toBeUndefined();
-            expect(result.content).toContain("![");
+            expect(result.type).toBeUndefined();
         });
     });
 });

--- a/tests/core/parser/frontMatter.test.ts
+++ b/tests/core/parser/frontMatter.test.ts
@@ -107,4 +107,111 @@ Content`;
             content: "",
         });
     });
+
+    describe("type: image transformation", () => {
+        it("should extract markdown images from body and inject image_list", async () => {
+            const markdown = `---
+title: Photo Post
+type: image
+---
+Some text before.
+
+![alt1](photo1.jpg)
+
+![alt2](photo2.png)
+
+Some text after.`;
+
+            const result = await handleFrontMatter(markdown);
+
+            expect(result.title).toBe("Photo Post");
+            expect(result.image_list).toEqual(["photo1.jpg", "photo2.png"]);
+            expect(result.content).not.toContain("![");
+            expect(result.content).toContain("Some text before.");
+            expect(result.content).toContain("Some text after.");
+        });
+
+        it("should extract Obsidian embed images from body", async () => {
+            const markdown = `---
+title: Obsidian Photos
+type: image
+---
+![[image1.png]]
+![[image2.jpg|description]]
+Text between images.`;
+
+            const result = await handleFrontMatter(markdown);
+
+            expect(result.image_list).toEqual(["image1.png", "image2.jpg"]);
+            expect(result.content).not.toContain("![[");
+            expect(result.content).toContain("Text between images.");
+        });
+
+        it("should extract mixed markdown and Obsidian images", async () => {
+            const markdown = `---
+title: Mixed Images
+type: image
+---
+![](md.jpg)
+![[obsidian.png]]
+Text.`;
+
+            const result = await handleFrontMatter(markdown);
+
+            expect(result.image_list).toEqual(["md.jpg", "obsidian.png"]);
+        });
+
+        it("should not transform when type is not image", async () => {
+            const markdown = `---
+title: Normal Post
+type: article
+---
+![](photo.jpg)
+Text.`;
+
+            const result = await handleFrontMatter(markdown);
+
+            expect(result.image_list).toBeUndefined();
+            expect(result.content).toContain("![");
+        });
+
+        it("should not transform when image_list already exists in frontmatter", async () => {
+            const markdown = `---
+title: Manual Image List
+type: image
+image_list:
+  - custom1.jpg
+  - custom2.jpg
+---
+![](photo.jpg)
+Text.`;
+
+            const result = await handleFrontMatter(markdown);
+
+            expect(result.image_list).toEqual(["custom1.jpg", "custom2.jpg"]);
+            expect(result.content).toContain("![");
+        });
+
+        it("should not transform when body has no images", async () => {
+            const markdown = `---
+title: No Images
+type: image
+---
+Just text, no images.`;
+
+            const result = await handleFrontMatter(markdown);
+
+            expect(result.image_list).toBeUndefined();
+            expect(result.content).toContain("Just text, no images.");
+        });
+
+        it("should not transform when frontmatter is absent", async () => {
+            const markdown = "![](photo.jpg)\nJust text.";
+
+            const result = await handleFrontMatter(markdown);
+
+            expect(result.image_list).toBeUndefined();
+            expect(result.content).toContain("![");
+        });
+    });
 });

--- a/tests/node/render.test.ts
+++ b/tests/node/render.test.ts
@@ -108,5 +108,118 @@ describe("render.ts tests", () => {
 
             expect(result.gzhContent.title).toBe("Direct Content");
         });
+
+        describe("type: image transformation", () => {
+            it("should extract markdown images and inject image_list", async () => {
+                const getInputContent = vi.fn().mockResolvedValue({
+                    content: "---\ntitle: Photo Post\ntype: image\n---\nSome text before.\n\n![alt1](photo1.jpg)\n\n![alt2](photo2.png)\n\nSome text after.",
+                    absoluteDirPath: "/test/path",
+                });
+
+                const result = await prepareRenderContext(
+                    undefined,
+                    { theme: "phycat", highlight: "solarized-light", macStyle: false, footnote: false },
+                    getInputContent,
+                );
+
+                expect(result.gzhContent.image_list).toEqual(["photo1.jpg", "photo2.png"]);
+                expect(result.gzhContent.content).not.toContain("![");
+                expect(result.gzhContent.content).toContain("Some text before.");
+                expect(result.gzhContent.content).toContain("Some text after.");
+            });
+
+            it("should extract Obsidian embed images", async () => {
+                const getInputContent = vi.fn().mockResolvedValue({
+                    content: "---\ntitle: Obsidian Photos\ntype: image\n---\n![[image1.png]]\n![[image2.jpg|description]]\nText between images.",
+                    absoluteDirPath: "/test/path",
+                });
+
+                const result = await prepareRenderContext(
+                    undefined,
+                    { theme: "phycat", highlight: "solarized-light", macStyle: false, footnote: false },
+                    getInputContent,
+                );
+
+                expect(result.gzhContent.image_list).toEqual(["image1.png", "image2.jpg"]);
+                expect(result.gzhContent.content).not.toContain("![[");
+                expect(result.gzhContent.content).toContain("Text between images.");
+            });
+
+            it("should extract mixed markdown and Obsidian images", async () => {
+                const getInputContent = vi.fn().mockResolvedValue({
+                    content: "---\ntitle: Mixed Images\ntype: image\n---\n![](md.jpg)\n![[obsidian.png]]\nText.",
+                    absoluteDirPath: "/test/path",
+                });
+
+                const result = await prepareRenderContext(
+                    undefined,
+                    { theme: "phycat", highlight: "solarized-light", macStyle: false, footnote: false },
+                    getInputContent,
+                );
+
+                expect(result.gzhContent.image_list).toEqual(["md.jpg", "obsidian.png"]);
+            });
+
+            it("should not transform when type is not image", async () => {
+                const getInputContent = vi.fn().mockResolvedValue({
+                    content: "---\ntitle: Normal Post\ntype: article\n---\n![](photo.jpg)\nText.",
+                    absoluteDirPath: "/test/path",
+                });
+
+                const result = await prepareRenderContext(
+                    undefined,
+                    { theme: "phycat", highlight: "solarized-light", macStyle: false, footnote: false },
+                    getInputContent,
+                );
+
+                expect(result.gzhContent.image_list).toBeUndefined();
+            });
+
+            it("should not transform when image_list already exists in frontmatter", async () => {
+                const getInputContent = vi.fn().mockResolvedValue({
+                    content: "---\ntitle: Manual Image List\ntype: image\nimage_list:\n  - custom1.jpg\n  - custom2.jpg\n---\n![](photo.jpg)\nText.",
+                    absoluteDirPath: "/test/path",
+                });
+
+                const result = await prepareRenderContext(
+                    undefined,
+                    { theme: "phycat", highlight: "solarized-light", macStyle: false, footnote: false },
+                    getInputContent,
+                );
+
+                expect(result.gzhContent.image_list).toEqual(["custom1.jpg", "custom2.jpg"]);
+            });
+
+            it("should not transform when body has no images", async () => {
+                const getInputContent = vi.fn().mockResolvedValue({
+                    content: "---\ntitle: No Images\ntype: image\n---\nJust text, no images.",
+                    absoluteDirPath: "/test/path",
+                });
+
+                const result = await prepareRenderContext(
+                    undefined,
+                    { theme: "phycat", highlight: "solarized-light", macStyle: false, footnote: false },
+                    getInputContent,
+                );
+
+                expect(result.gzhContent.image_list).toBeUndefined();
+                expect(result.gzhContent.content).toContain("Just text, no images.");
+            });
+
+            it("should not transform when frontmatter is absent", async () => {
+                const getInputContent = vi.fn().mockResolvedValue({
+                    content: "![](photo.jpg)\nJust text.",
+                    absoluteDirPath: "/test/path",
+                });
+
+                const result = await prepareRenderContext(
+                    undefined,
+                    { theme: "phycat", highlight: "solarized-light", macStyle: false, footnote: false },
+                    getInputContent,
+                );
+
+                expect(result.gzhContent.image_list).toBeUndefined();
+            });
+        });
     });
 });


### PR DESCRIPTION
## Summary

- 将 `type: image` → `image_list` 的转换逻辑从 CLI 层下沉到 core 的 `handleFrontMatter` 中
- 当 frontmatter 包含 `type: image` 时，自动从正文提取图片路径（支持 `![](path)` 和 `![[path]]` 语法），注入 `image_list`，并清理正文中的图片引用

## Changes

- `src/core/parser/frontMatterParser.ts`: 新增 `extractAndCleanImages` 函数，在 `handleFrontMatter` 中检测 `type: image` 并自动处理
- `tests/core/parser/frontMatter.test.ts`: 新增 7 个测试用例覆盖各种场景

## Motivation

参见 caol64/wenyan-cli#32 的讨论。原方案在 CLI 层做转换，桌面端无法复用。将逻辑下沉到 core 后，CLI 和桌面端都通过 core 的 `handleFrontMatter` 自动处理，无需各自实现。

## How it works

```
用户在 frontmatter 写 type: image
→ core 的 handleFrontMatter 检测到 type: image
→ 从正文提取所有 ![]() 和 ![[]] 图片路径
→ 注入 image_list（如果 frontmatter 未手动指定）
→ 清理正文中的图片引用（小绿书图片在列表展示，不在正文重复）
→ 现有的 image_list 分发逻辑正常工作
```

## Test plan

- [x] 新增 7 个测试用例全部通过
- [x] 原有 6 个 frontmatter 测试全部通过
- [x] typecheck 通过
- [x] build 通过

Closes caol64/wenyan-cli#32