### PR TITLE
docs: 补充小绿书（图片消息）相关文档

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,7 @@ interface WenyanOptions {
 ### handleFrontMatter
 
 ```ts
-handleFrontMatter(markdown: string): Promise<StyledContent>
+handleFrontMatter(markdown: string): Promise<FrontMatterResult>
 ```
 
 解析 Markdown 中的 Front Matter（YAML 头信息）。
@@ -98,8 +98,26 @@ interface FrontMatterResult {
   need_open_comment?: boolean;
   only_fans_can_comment?: boolean;
   image_list?: string[];
+  type?: string;
 }
 ```
+
+| 字段                     | 说明                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| content                | 解析后的 Markdown 正文                                                                    |
+| title                  | 文章标题                                                                                 |
+| description            | 文章描述                                                                                 |
+| cover                  | 封面图片路径                                                                               |
+| author                 | 作者                                                                                   |
+| source_url             | 原文链接                                                                                 |
+| need_open_comment      | 是否打开评论                                                                               |
+| only_fans_can_comment  | 是否仅粉丝可评论                                                                             |
+| image_list             | 图片路径列表，用于图片消息（小绿书）发布。最多 20 张，第一张为封面                                                  |
+| type                   | 文章类型。设为 `"image"` 时，Node 环境下会自动从正文提取图片路径注入 `image_list`，并从正文中移除图片引用（详见 Node 文档） |
+
+> [!NOTE]
+>
+> `type: image` 的自动提取逻辑仅在 Node 环境的 `prepareRenderContext` 中执行（浏览器环境仅解析 frontmatter，不自动提取图片）。
 
 ### renderMarkdown
 
@@ -277,3 +295,4 @@ applyStylesWithTheme
 * macOS SwiftUI（WebView）
 * Server-side 预渲染
 * Markdown → 微信公众号文章
+* 图片消息（小绿书）发布

--- a/docs/node.md
+++ b/docs/node.md
@@ -8,6 +8,7 @@
 > * Server-side 渲染
 > * 自动化内容生产
 > * Markdown → 微信草稿流水线
+> * 图片消息（小绿书）发布
 
 ## 概览
 
@@ -21,6 +22,7 @@ npm install jsdom
 
 ```ts
 renderStyledContent()
+prepareRenderContext()
 ```
 
 ## StyledContent 数据结构
@@ -30,7 +32,9 @@ export interface StyledContent {
   content: string;       // 最终 HTML
   title?: string;        // Front Matter 中的 title
   cover?: string;        // Front Matter 中的 cover
-  description?: string; // Front Matter 中的 description
+  description?: string;  // Front Matter 中的 description
+  image_list?: string[]; // 图片路径列表（小绿书）
+  type?: string;         // 文章类型
 }
 ```
 
@@ -39,13 +43,14 @@ export interface StyledContent {
 ```ts
 async function renderStyledContent(
   content: string,
-  options?: ApplyStylesOptions
-): Promise<StyledContent>
+  options?: ApplyStylesOptions,
+  coreInstance?: WenyanCoreInstance
+): Promise<string>
 ```
 
 ### 功能说明
 
-完整执行以下流程：
+渲染 Markdown 并应用主题样式，输出 HTML 字符串。
 
 ```text
 Markdown
@@ -66,13 +71,10 @@ JSDOM 创建 DOM
 ```ts
 import { renderStyledContent } from "@wenyan-md/core/node";
 
-const result = await renderStyledContent(markdown, {
+const html = await renderStyledContent(markdown, {
   themeId: "default",
   hlThemeId: "solarized-light",
 });
-
-console.log(result.content);
-console.log(result.title);
 ```
 
 ### 参数说明
@@ -81,18 +83,97 @@ console.log(result.title);
 | ------- | -------------------- | -------------- |
 | content | `string`             | 原始 Markdown    |
 | options | `ApplyStylesOptions` | 样式选项（与浏览器版本一致） |
+| coreInstance | `WenyanCoreInstance` | 可选，自定义核心实例 |
 
 > [!NOTE]
 > 
 > Node 版本与浏览器版本使用 **完全一致的 ApplyStylesOptions**
 
-## 五、设计说明（Node 渲染）
+## prepareRenderContext
+
+```ts
+async function prepareRenderContext(
+  inputContent: string | undefined,
+  options: RenderOptions,
+  getInputContent: GetInputContentFn
+): Promise<RenderContext>
+```
+
+完整的渲染上下文准备函数，包括内容读取、frontmatter 解析、图片消息处理和主题渲染。CLI 和 Server 模式内部均使用此函数。
+
+### 功能说明
+
+```text
+读取 Markdown 内容
+  ↓
+handleFrontMatter 解析
+  ↓
+type: image 自动提取图片（如有）
+  ↓
+判断是否为图片消息
+  ↓  是                     ↓  否
+跳过主题渲染              应用主题样式
+  ↓                        ↓
+返回 RenderContext
+```
+
+### RenderContext
+
+```ts
+export interface RenderContext {
+  gzhContent: StyledContent;
+  absoluteDirPath: string | undefined;
+}
+```
+
+### 图片消息（小绿书）处理
+
+当 frontmatter 中包含 `image_list` 或 `type: image` 时，`prepareRenderContext` 会自动识别为图片消息模式：
+
+1. **`type: image` 自动提取**：如果设置 `type: image` 且未手动指定 `image_list`，函数会：
+   - 渲染 Markdown 为 HTML
+   - 提取所有 `<img>` 的 `src` 路径
+   - 将路径列表注入 `image_list`
+   - 从正文中移除所有图片节点（空的父 `<p>` 也会一并移除）
+
+2. **跳过主题渲染**：当存在 `image_list` 时，不应用主题样式，直接返回原始内容
+
+### 示例
+
+```ts
+import { prepareRenderContext } from "@wenyan-md/core/node";
+
+const { gzhContent, absoluteDirPath } = await prepareRenderContext(
+  undefined,
+  { theme: "default", highlight: "solarized-light", macStyle: true, footnote: true },
+  myGetInputContentFn,
+);
+
+if (gzhContent.image_list && gzhContent.image_list.length > 0) {
+  // 图片消息路径
+  await publishImageTextToWechatDraft({
+    ...gzhContent,
+    title: gzhContent.title!,
+    images: gzhContent.image_list,
+  });
+} else {
+  // 图文文章路径
+  await publishToWechatDraft({
+    ...gzhContent,
+    title: gzhContent.title!,
+  });
+}
+```
+
+## 设计说明（Node 渲染）
 
 * Node 渲染 **不会依赖浏览器**
 * 所有 DOM 操作均基于 JSDOM
 * 输出结果是 **完整可用的 HTML**
+* 图片消息模式自动跳过主题渲染，保持图片为主体
 * 可直接用于：
 
   * 文件写入
   * 微信 API
   * 静态站点生成
+  * 图片消息（小绿书）发布

--- a/docs/wechat.md
+++ b/docs/wechat.md
@@ -12,6 +12,7 @@
 * 自动替换 `<img src>`
 * 自动选择封面
 * 发布到公众号草稿箱
+* 支持图文文章与图片消息（小绿书）
 
 首先，请安装下列库：
 
@@ -21,10 +22,12 @@ npm install jsdom form-data-encoder formdata-node
 
 ## publishToWechatDraft
 
+发布 **图文文章** 到微信公众号草稿箱。
+
 ```ts
 async function publishToWechatDraft(
   articleOptions: ArticleOptions, publishOptions?: PublishOptions
-): Promise<any>
+): Promise<WechatPublishResponse>
 ```
 
 ### ArticleOptions
@@ -44,7 +47,7 @@ export interface ArticleOptions {
 | 参数           | 说明              |
 | ------------ | --------------- |
 | title        | 文章标题     |
-| content      | 文章内容 |
+| content      | 文章内容（HTML） |
 | cover        | 文章封面       |
 | author       | 作者       |
 | source_url   | 原文地址       |
@@ -83,11 +86,57 @@ await publishToWechatDraft({
   title: "我的第一篇文章",
   content: htmlContent,
   cover: "", // 不指定封面，自动使用正文第一张图片
-  {
-    relativePath: process.cwd(),
-  }
+}, {
+  relativePath: process.cwd(),
 });
 ```
+
+## publishImageTextToWechatDraft
+
+发布 **图片消息（小绿书）** 到微信公众号草稿箱。
+
+```ts
+async function publishImageTextToWechatDraft(
+  articleOptions: ImageTextArticleOptions, publishOptions?: PublishOptions
+): Promise<WechatPublishResponse>
+```
+
+图片消息以图片为主体，适合发布图集类内容。发布后在公众号中显示为「小绿书」样式。
+
+### ImageTextArticleOptions
+
+```ts
+export interface ImageTextArticleOptions extends ArticleOptions {
+  images: string[];
+}
+```
+
+`ImageTextArticleOptions` 继承 `ArticleOptions` 的所有字段，并新增以下字段：
+
+| 参数    | 说明                                           |
+| ----- | -------------------------------------------- |
+| images | 图片路径列表（本地路径或网络 URL），至少 1 张，最多 20 张。第一张默认为封面 |
+
+### 示例
+
+```ts
+await publishImageTextToWechatDraft({
+  title: "人勤春来早，读书正当时",
+  content: "<p>正文内容</p>",
+  images: [
+    "./photos/1.jpeg",
+    "./photos/2.jpeg",
+    "./photos/3.jpeg",
+  ],
+}, {
+  relativePath: process.cwd(),
+});
+```
+
+### 封面选择规则
+
+1. 如果显式传入 `cover` → 使用该图片作为封面
+2. 否则使用 `images` 列表中的第一张图片
 
 ## 图片处理逻辑说明
 
@@ -110,12 +159,11 @@ HTML
 替换 src
 ```
 
-### 封面选择规则
+### 封面选择规则（图文文章）
 
 1. 如果显式传入 `cover` → 使用该图片
 2. 否则使用正文中第一张图片
 3. 如果都不存在 → 抛出错误
-
 
 ## 错误处理说明
 
@@ -126,8 +174,11 @@ HTML
 * 图片大小为 0
 * 微信接口返回 errcode
 * 无法确定封面图
+* 图片消息未提供图片（`images` 为空）
 
 ## 典型完整流程
+
+### 图文文章
 
 ```ts
 import {
@@ -143,12 +194,30 @@ await publishToWechatDraft({
 });
 ```
 
+### 图片消息（小绿书）
+
+```ts
+import {
+  renderStyledContent,
+  publishImageTextToWechatDraft
+} from "@wenyan-md/core/node";
+
+const { content, title, image_list } = await renderStyledContent(markdown);
+
+await publishImageTextToWechatDraft({
+  title: title ?? "未命名文章",
+  content,
+  images: image_list!,
+});
+```
+
 ## 适用场景
 
 * 自动化内容发布
 * Markdown → 微信草稿 CLI
 * CI / 定时任务
 * 内容生产后台
+* 图集类内容发布（小绿书）
 
 ## 架构设计说明
 
@@ -163,7 +232,9 @@ await publishToWechatDraft({
 
 ## Markdown Frontmatter 说明
 
-使用`publishToWechatDraft`接口发布文章时，每篇文章顶部需包含 frontmatter：
+### 图文文章
+
+使用 `publishToWechatDraft` 接口发布文章时，每篇文章顶部需包含 frontmatter：
 
 ```md
 ---
@@ -174,6 +245,37 @@ cover: /path/to/cover.jpg
 
 -   `title`：必填
 -   `cover`：本地路径或网络图片（正文有图可省略）
+
+### 图片消息（小绿书）
+
+使用 `publishImageTextToWechatDraft` 接口时，可通过以下两种方式指定图片：
+
+**方式一：手动指定 image_list**
+
+```md
+---
+title: 人勤春来早，读书正当时
+image_list:
+  - ./1.jpeg
+  - ./2.jpeg
+  - ./3.jpeg
+---
+```
+
+**方式二：使用 type: image 自动提取（推荐）**
+
+```md
+---
+title: 人勤春来早，读书正当时
+type: image
+---
+
+![](./1.jpeg)
+![](./2.jpeg)
+![](./3.jpeg)
+```
+
+设置 `type: image` 后，Core 会自动从正文中提取所有图片路径注入 `image_list`，并从正文中移除图片引用。
 
 ## 微信公众号 IP 白名单
 


### PR DESCRIPTION
## Summary

补充小绿书（图片消息）功能的相关文档，与之前合并的 PR #13、#20 的代码变更对齐。

### 变更内容

- **docs/wechat.md**: 新增 `publishImageTextToWechatDraft()` API 文档，包括 `ImageTextArticleOptions` 接口、封面选择规则、使用示例；补全 `ArticleOptions` 中 `need_open_comment` / `only_fans_can_comment` 字段；新增小绿书 frontmatter 说明（`image_list` 和 `type: image` 两种方式）
- **docs/api.md**: `FrontMatterResult` 补充 `type?: string` 和 `image_list?: string[]` 字段文档，说明 `type: image` 的自动提取行为
- **docs/node.md**: 新增 `prepareRenderContext()` 函数文档，说明 `type: image` → `image_list` 自动提取逻辑和图片消息渲染路径（跳过主题样式）；`StyledContent` 补充 `image_list` 和 `type` 字段

## Test plan

- [ ] 检查文档内容与实际 API 签名一致
- [ ] 检查 frontmatter 说明与实际行为一致