### PR TITLE
fix: decode URL-encoded characters in local image paths

### DIFF
--- a/src/node/clientPublish.ts
+++ b/src/node/clientPublish.ts
@@ -199,7 +199,8 @@ async function uploadLocalImage(
     headers: Record<string, string>,
     relativePath?: string,
 ): Promise<string | null> {
-    const imagePath = RuntimeEnv.resolveLocalPath(originalUrl, relativePath);
+    const decodedUrl = decodeURIComponent(originalUrl);
+    const imagePath = RuntimeEnv.resolveLocalPath(decodedUrl, relativePath);
     let fileBuffer: Buffer;
     try {
         fileBuffer = await readBinaryFile(imagePath);


### PR DESCRIPTION
## Summary

When Markdown contains image paths with spaces (e.g. `media/my image.png`), the HTML renderer encodes them as `%20` in the `<img src>` attribute. `uploadLocalImage` passed the raw `src` value to `resolveLocalPath` without decoding, causing `ENOENT` errors.

## Changes

- Added `decodeURIComponent` before `resolveLocalPath` in `uploadLocalImage` (`src/node/clientPublish.ts`)
- Affects `uploadLocalImages`, `uploadCover`, and `uploadImageList` since they all route through `uploadLocalImage`

## Test plan

- [x] Existing 25 tests in `clientPublish.test.ts` pass
- [x] Verified that parser tests confirm `%20` encoding in output (e.g. `my%20image.png`)
- [ ] Manual test: publish an article containing an image with spaces in the path