### PR TITLE
fix: add friendly error message for WeChat error 45166

### DIFF
--- a/src/wechat.ts
+++ b/src/wechat.ts
@@ -111,9 +111,14 @@ export function createWechatClient(httpAdapter: HttpAdapter) {
     };
 }
 
+const WECHAT_ERROR_HINTS: Record<number, string> = {
+    45166: "内容超长。小绿书模式有内容长度限制，请精简正文后重试。",
+};
+
 function assertWechatSuccess<T extends object>(data: T | WechatErrorResponse): asserts data is T {
     if ("errcode" in data) {
-        throw new Error(`${data.errcode}: ${data.errmsg}`);
+        const hint = WECHAT_ERROR_HINTS[data.errcode];
+        throw new Error(hint ? `${data.errcode}: ${hint} (${data.errmsg})` : `${data.errcode}: ${data.errmsg}`);
     }
 }
 

--- a/tests/wechat.test.ts
+++ b/tests/wechat.test.ts
@@ -51,6 +51,21 @@ describe("wechat.ts tests", () => {
         );
     });
 
+    it("should include friendly hint for known error code 45166", async () => {
+        fetch.mockResolvedValue(
+            new Response(JSON.stringify({
+                errcode: 45166,
+                errmsg: "content too long",
+            })),
+        );
+
+        const client = createWechatClient(httpAdapter);
+
+        await expect(client.fetchAccessToken("app-id", "app-secret")).rejects.toThrow(
+            "45166: 内容超长",
+        );
+    });
+
     it("should upload material with multipart request and normalize returned url", async () => {
         const file = new Blob(["mock image content"], { type: "image/png" });
         const multipart: MultipartBody = {


### PR DESCRIPTION
## Summary

When publishing to 小绿书 (newspic) mode, WeChat returns error 45166 if content exceeds the length limit. The raw error message (`45166: <errmsg>`) gives no actionable guidance.

## Changes

- Added `WECHAT_ERROR_HINTS` map in `src/wechat.ts` for known error codes
- Error 45166 now shows: `45166: 内容超长。小绿书模式有内容长度限制，请精简正文后重试。 (<original errmsg>)`
- Unknown error codes continue to show the original `errcode: errmsg` format
- Added test case for 45166 hint rendering

## Test plan

- [x] All 6 tests in `wechat.test.ts` pass (including new 45166 test)
- [x] Existing 40013 error test still passes (verifies fallback path unchanged)