### PR TITLE
fix: decode URL-encoded characters in resolveLocalPath

### DIFF
--- a/src/node/publish.ts
+++ b/src/node/publish.ts
@@ -54,7 +54,8 @@ async function uploadImage(
         fileData = new Blob([arrayBuffer], { type: contentType });
     } else {
         // 本地路径
-        const resolvedPath = RuntimeEnv.resolveLocalPath(imageUrl, relativePath);
+        const decodedUrl = decodeURIComponent(imageUrl);
+        const resolvedPath = RuntimeEnv.resolveLocalPath(decodedUrl, relativePath);
         const stats = await stat(resolvedPath);
         if (stats.size === 0) {
             throw new Error(`本地图片大小为0，无法上传: ${resolvedPath}`);

--- a/tests/node/publish.test.ts
+++ b/tests/node/publish.test.ts
@@ -152,4 +152,11 @@ describe("publish.ts tests", () => {
             publishToDraft("无图测试", "<p>只有文字</p>")
         ).rejects.toThrow("你必须指定一张封面图或者在正文中至少出现一张图片。");
     });
+
+    it("should handle URL-encoded image paths with spaces", async () => {
+        const imgPath = path.join(__dirname, "../wenyan.jpg");
+        const encodedPath = encodeURIComponent(imgPath);
+        const result = await publishToDraft("编码路径测试", "<p>正文</p>", encodedPath);
+        expect(result).toHaveProperty("media_id", "mock_article_media_id");
+    });
 });


### PR DESCRIPTION
## 问题

与 #22 相同的 bug，但影响的是**直接发布路径**（不经 server）。

当图片文件名含空格时，`publish.ts` → `uploadImage()` 中 `resolveLocalPath` 收到 URL 编码的路径（`%20`），导致文件找不到。

## 修复方案

与 #22 相同的修复方式：在调用 `resolveLocalPath` 前 `decodeURIComponent`。

| 路径 | 修复位置 | PR |
|------|---------|-----|
| 服务端发布（clientPublish） | `uploadLocalImage()` | #22 ✅ 已合并 |
| 直接发布（publish） | `uploadImage()` | 本 PR |

## 变更

- `src/node/publish.ts`：在本地路径分支中添加 `decodeURIComponent`
- `tests/node/publish.test.ts`：新增测试用例验证 URL 编码路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)