### PR TITLE
fix: 嵌套列表转换避免微信编辑器多余标记

### DIFF
--- a/src/core/renderer/wechatPostRender.ts
+++ b/src/core/renderer/wechatPostRender.ts
@@ -57,20 +57,45 @@ export function wechatPostRender(element: HTMLElement): void {
         li.appendChild(section);
     });
 
-    // 5. 提升嵌套列表（微信兼容）
-    // 微信公众号编辑器无法正确渲染 <li> 内嵌套的 <ul>/<ol>，
-    // 需要将嵌套列表从 <li> 中提出，变为同级元素。
-    // 参考: https://github.com/doocs/md
-    const nestedLists = element.querySelectorAll<HTMLUListElement | HTMLOListElement>(
-        "li > section > ul, li > section > ol",
-    );
+    // 5. 转换嵌套列表（微信兼容）
+    // 微信公众号编辑器会将 <ul>/<ol> 直接嵌套在另一个 <ul>/<ol> 内时
+    // 添加额外的项目符号或编号。将嵌套列表转换为带文本标记的 <section>
+    // 元素，保留视觉层次但避免触发微信的列表渲染。
+    const flattenNestedLists = () => {
+        let nestedLists = element.querySelectorAll<HTMLUListElement | HTMLOListElement>(
+            "li > section > ul, li > section > ol",
+        );
 
-    nestedLists.forEach((nestedList) => {
-        const li = nestedList.closest("li");
-        if (li) {
-            li.insertAdjacentElement("afterend", nestedList);
+        while (nestedLists.length > 0) {
+            // 从最深层开始处理（querySelectorAll 按文档序返回，reverse 后最深的先处理）
+            Array.from(nestedLists).reverse().forEach((nestedList) => {
+                const isOrdered = nestedList.tagName === "OL";
+                const doc = element.ownerDocument;
+                const items = Array.from(nestedList.children).filter(
+                    (child) => child.tagName === "LI",
+                );
+
+                const wrapper = doc.createElement("section");
+                wrapper.style.marginLeft = "1em";
+
+                items.forEach((item, index) => {
+                    const content = item.querySelector("section");
+                    const sectionEl = doc.createElement("section");
+                    const marker = isOrdered ? `${index + 1}. ` : "• ";
+                    sectionEl.innerHTML = marker + (content?.innerHTML ?? item.innerHTML);
+                    wrapper.appendChild(sectionEl);
+                });
+
+                nestedList.replaceWith(wrapper);
+            });
+
+            nestedLists = element.querySelectorAll<HTMLUListElement | HTMLOListElement>(
+                "li > section > ul, li > section > ol",
+            );
         }
-    });
+    };
+
+    flattenNestedLists();
 
     // 6. 设置字体颜色为黑色，防止黑暗模式影响
     element.style.color = "rgb(0, 0, 0)";

--- a/tests/wechatPostRender.test.ts
+++ b/tests/wechatPostRender.test.ts
@@ -18,33 +18,42 @@ describe("wechatPostRender", () => {
         expect(li.querySelector("section")!.textContent).toBe("item");
     });
 
-    it("should lift nested ul out of li for WeChat compatibility", () => {
+    it("should convert nested ul to styled section elements", () => {
         const element = createDom(
             "<ul><li>parent<ul><li>child</li></ul></li></ul>",
         );
         wechatPostRender(element);
 
-        // 嵌套的 <ul> 应该被移到 <li> 之后，成为同级元素
-        const parentLi = element.querySelectorAll("li")[0];
-        const nestedUl = parentLi.nextElementSibling;
+        // 嵌套的 <ul> 应该被转换为 <section>，保留在 <li> 内部
+        const parentLi = element.querySelector("li")!;
+        expect(parentLi.querySelector("ul")).toBeNull();
+        expect(parentLi.querySelector("ol")).toBeNull();
 
-        expect(nestedUl?.tagName).toBe("UL");
-        expect(nestedUl?.querySelector("li")?.textContent).toBe("child");
-        // <li> 内容只剩文本
-        expect(parentLi.querySelector("section")!.textContent).toBe("parent");
+        // 验证转换后的 section 结构
+        const wrapper = parentLi.querySelector("section > section")!;
+        expect(wrapper).not.toBeNull();
+        expect(wrapper.style.marginLeft).toBe("1em");
+
+        // 验证子项内容带有项目符号标记
+        const items = wrapper.querySelectorAll(":scope > section");
+        expect(items.length).toBe(1);
+        expect(items[0].textContent).toBe("• child");
     });
 
-    it("should lift nested ol out of li for WeChat compatibility", () => {
+    it("should convert nested ol to styled section elements with numbered markers", () => {
         const element = createDom(
-            "<ul><li>parent<ol><li>child</li></ol></li></ul>",
+            "<ul><li>parent<ol><li>first</li><li>second</li></ol></li></ul>",
         );
         wechatPostRender(element);
 
-        const parentLi = element.querySelectorAll("li")[0];
-        const nestedOl = parentLi.nextElementSibling;
+        const parentLi = element.querySelector("li")!;
+        expect(parentLi.querySelector("ol")).toBeNull();
 
-        expect(nestedOl?.tagName).toBe("OL");
-        expect(nestedOl?.querySelector("li")?.textContent).toBe("child");
+        const wrapper = parentLi.querySelector("section > section")!;
+        const items = wrapper.querySelectorAll(":scope > section");
+        expect(items.length).toBe(2);
+        expect(items[0].textContent).toBe("1. first");
+        expect(items[1].textContent).toBe("2. second");
     });
 
     it("should handle deeply nested lists", () => {
@@ -53,22 +62,29 @@ describe("wechatPostRender", () => {
         );
         wechatPostRender(element);
 
-        const lis = element.querySelectorAll("li");
-        const uls = element.querySelectorAll("ul");
+        // 不应该有任何 <ul>/<ol> 嵌套在 <li> 的 <section> 内
+        const allUls = element.querySelectorAll("ul");
+        const allOls = element.querySelectorAll("ol");
+        // Only the top-level <ul> should remain
+        expect(allUls.length).toBe(1);
+        expect(allOls.length).toBe(0);
 
-        // 所有列表项的文本内容应该正确
-        const texts = Array.from(lis).map((li) => li.textContent);
-        expect(texts).toContain("l1");
-        expect(texts).toContain("l2");
-        expect(texts).toContain("l3");
+        // 验证内容层级正确
+        const text = element.textContent!;
+        expect(text).toContain("l1");
+        expect(text).toContain("• l2");
+        expect(text).toContain("• l3");
+    });
 
-        // 不应该有任何 <ul> 嵌套在 <li> 的 <section> 内
-        element.querySelectorAll("li").forEach((li) => {
-            const section = li.querySelector("section");
-            if (section) {
-                expect(section.querySelector("ul")).toBeNull();
-                expect(section.querySelector("ol")).toBeNull();
-            }
-        });
+    it("should preserve HTML content inside nested list items", () => {
+        const element = createDom(
+            "<ul><li>parent<ul><li><strong>bold</strong> child</li></ul></li></ul>",
+        );
+        wechatPostRender(element);
+
+        const wrapper = element.querySelector("section > section")!;
+        const item = wrapper.querySelector(":scope > section")!;
+        expect(item.innerHTML).toContain("<strong>bold</strong>");
+        expect(item.textContent).toBe("• bold child");
     });
 });


### PR DESCRIPTION
## 问题

通过 `wenyan publish` 推送含嵌套列表的文章到微信公众号后，出现多余的项目符号和编号。例如：

```markdown
- **MCAL 层**，包含：
    - 内部 Flash 驱动
    - 内部 EEPROM 驱动
```

在公众号中 "内部 Flash 驱动" 上方多出一个黑点。

```markdown
3. 扇区重组：
    - 当活动扇区将满时，有效数据复制到另一个已擦除扇区
    ...
```

在公众号中子列表上方多出一个 "4."。

## 根因

`wechatPostRender` 第 5 步将嵌套的 `<ul>`/`<ol>` 从 `<li>` 中提取出来，放到父 `<li>` 的后面作为同级元素。但这导致 `<ul>`/`<ol>` 成为另一个 `<ul>`/`<ol>` 的直接子元素（非 `<li>` 内），属于无效 HTML。微信编辑器对这种结构会额外添加列表标记。

虽然 doocs/md 使用了相同的"提升"方案（`modifyHtmlStructure`），但 doocs/md 在提升之前已通过 `juice` 将所有 CSS 内联到元素上，因此微信编辑器能正确渲染。wenyan-core 的渲染管线未做等价的 CSS 内联，导致微信编辑器对裸 `<ul>`/`<ol>` 应用默认列表样式。

## 修复方案

将嵌套的 `<ul>`/`<ol>` 转换为带文本标记（`•` 或 `1.` `2.` 等）的 `<section>` 元素：

- 保留在 `<li>` 内部（不产生无效 HTML 嵌套）
- 通过 `margin-left: 1em` 保持缩进层次
- 使用文本标记代替 HTML 列表标记，避免触发微信的列表渲染
- 从最深层开始处理，支持多级嵌套

## 测试

- 更新 `tests/wechatPostRender.test.ts`，验证新行为
- 5 个测试全部通过
- `tests/core/renderer/wechatPostRender.test.ts` 中 1 个 Mermaid 测试失败为既存问题（JSDOM 颜色格式差异），与本次改动无关