### PR TITLE
fix: clean empty elements after image extraction in 小绿书 mode

### DIFF
--- a/src/node/render.ts
+++ b/src/node/render.ts
@@ -30,7 +30,12 @@ async function extractAndCleanImages(body: string): Promise<{ imagePaths: string
         }
     }
 
-    return { imagePaths, cleanedHtml: wenyan!.outerHTML };
+    // 清理移除图片后残留的空元素（如 markdown 空行产生的空段落）
+    Array.from(wenyan!.children)
+        .filter(el => el.textContent?.trim() === "")
+        .forEach(el => el.remove());
+
+    return { imagePaths, cleanedHtml: wenyan!.innerHTML.trim() };
 }
 
 const nodeMermaidRenderer = createNodeMermaidRenderer();


### PR DESCRIPTION
## Summary

When `type: image` auto-extracts images from markdown content for 小绿书 (image-text post) publishing, the existing code removes `<img>` tags and their empty `<p>` parents. However, empty elements produced by blank lines between images remain in the output, causing visible blank space between the title and text in the published post.

## Changes

1. **Remove remaining empty elements**: After image extraction, iterate through all child elements and remove any with empty text content.
2. **Use `innerHTML.trim()` instead of `outerHTML`**: Strip the `<section id="wenyan">` wrapper and surrounding whitespace from the cleaned HTML output. For 小绿书 mode, the content is used as caption text and doesn't need the section wrapper (which is only relevant for theme-styled regular articles).

## Test Plan

- [x] Create a markdown file with `type: image` and multiple images separated by blank lines, followed by text content
- [x] Publish via `wenyan publish` - verify the post appears as 小绿书 without blank space between title and text