### PR TITLE
fix: 小绿书模式提取图片后段落间距翻倍

### DIFF
--- a/src/node/render.ts
+++ b/src/node/render.ts
@@ -30,7 +30,28 @@ async function extractAndCleanImages(body: string): Promise<{ imagePaths: string
         }
     }
 
-    return { imagePaths, cleanedHtml: wenyan!.outerHTML };
+    // Remove remaining empty elements produced by blank lines between images
+    for (const child of Array.from(wenyan!.children)) {
+        if (!child.textContent?.trim()) {
+            child.remove();
+        }
+    }
+
+    // Collapse <p> tags to avoid double spacing in caption.
+    // Each <p> element contributes its own margin, creating visually doubled
+    // paragraph gaps in the WeChat image-text post caption. Unwrap <p> elements
+    // and insert <br> as paragraph separators instead.
+    const paragraphs = Array.from(wenyan!.querySelectorAll("p"));
+    for (const p of paragraphs) {
+        const frag = document.createDocumentFragment();
+        while (p.firstChild) {
+            frag.appendChild(p.firstChild);
+        }
+        frag.appendChild(document.createElement("br"));
+        p.parentNode?.replaceChild(frag, p);
+    }
+
+    return { imagePaths, cleanedHtml: wenyan!.innerHTML.trim() };
 }
 
 const nodeMermaidRenderer = createNodeMermaidRenderer();


### PR DESCRIPTION
## 问题

`type: image` 小绿书模式从正文中提取图片后，剩余的配文段落保留了 `<p>` 标签。每个 `<p>` 自带 CSS margin，相邻段落 margin 叠加，导致公众号 caption 区域段落间距视觉上翻倍。

此外，图片之间的空行在提取后会产生残留空白元素，导致标题和正文之间出现多余空隙。

## 改动

1. **合并 `<p>` 为 `<br>`**：提取图片后，将剩余的 `<p>` 标签拆解，段落边界用 `<br>` 替代，消除 margin 叠加产生的双倍间距
2. **清理空白元素**：移除图片间空行产生的残留空元素（原 #29 的修复已包含在此 PR 中）
3. **返回 `innerHTML.trim()`**：去掉外层 `<section id="wenyan">` 包裹，caption 不需要主题样式的 section 容器

## 测试

1. 创建一个 `type: image` 的 markdown 文件，包含多张图片（图片间有空行）和多个段落的配文
2. 通过 `wenyan publish` 发布
3. 验证小绿书 caption 中段落间距为单行，无标题与正文间的多余空隙