### PR TITLE
Add WeChat cover crop fields to draft publishing

### DIFF
--- a/src/core/parser/frontMatterParser.ts
+++ b/src/core/parser/frontMatterParser.ts
@@ -7,6 +7,8 @@ export interface FrontMatterResult {
     cover?: string;
     author?: string;
     source_url?: string;
+    pic_crop_235_1?: string;
+    pic_crop_1_1?: string;
     need_open_comment?: boolean;
     only_fans_can_comment?: boolean;
     image_list?: string[];
@@ -19,7 +21,19 @@ export async function handleFrontMatter(markdown: string): Promise<FrontMatterRe
     const { attributes, body } = fm(markdown);
     const result: FrontMatterResult = { content: body || "" };
     let head = "";
-    const { title, description, cover, author, source_url, need_open_comment, only_fans_can_comment, image_list, type } = attributes;
+    const {
+        title,
+        description,
+        cover,
+        author,
+        source_url,
+        pic_crop_235_1,
+        pic_crop_1_1,
+        need_open_comment,
+        only_fans_can_comment,
+        image_list,
+        type,
+    } = attributes;
     if (title) {
         result.title = title;
     }
@@ -35,6 +49,12 @@ export async function handleFrontMatter(markdown: string): Promise<FrontMatterRe
     }
     if (source_url) {
         result.source_url = source_url;
+    }
+    if (pic_crop_235_1) {
+        result.pic_crop_235_1 = String(pic_crop_235_1);
+    }
+    if (pic_crop_1_1) {
+        result.pic_crop_1_1 = String(pic_crop_1_1);
     }
     if (need_open_comment !== undefined) {
         result.need_open_comment = need_open_comment;

--- a/src/node/publish.ts
+++ b/src/node/publish.ts
@@ -114,7 +114,17 @@ export async function publishToWechatDraft(
     articleOptions: ArticleOptions,
     publishOptions: PublishOptions = {},
 ): Promise<WechatPublishResponse> {
-    const { title, content, cover, author, source_url, need_open_comment, only_fans_can_comment } = articleOptions;
+    const {
+        title,
+        content,
+        cover,
+        author,
+        source_url,
+        pic_crop_235_1,
+        pic_crop_1_1,
+        need_open_comment,
+        only_fans_can_comment,
+    } = articleOptions;
     const { appId, appSecret, relativePath } = publishOptions;
 
     const { appId: appIdFinal, appSecret: appSecretFinal } = await getAppIdAndSecret(appId, appSecret);
@@ -160,6 +170,8 @@ export async function publishToWechatDraft(
         thumb_media_id: thumbMediaId,
         author,
         content_source_url: source_url,
+        pic_crop_235_1,
+        pic_crop_1_1,
         need_open_comment: need_open_comment ? 1 : 0,
         only_fans_can_comment: only_fans_can_comment ? 1 : 0,
     });

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -17,6 +17,8 @@ export interface ArticleOptions {
     cover?: string;
     author?: string;
     source_url?: string;
+    pic_crop_235_1?: string;
+    pic_crop_1_1?: string;
     need_open_comment?: boolean;
     only_fans_can_comment?: boolean;
 }

--- a/src/wechat.ts
+++ b/src/wechat.ts
@@ -30,6 +30,8 @@ export interface WechatPublishOptions {
     content: string;
     thumb_media_id: string;
     content_source_url?: string;
+    pic_crop_235_1?: string;
+    pic_crop_1_1?: string;
     article_type?: "news" | "newspic";
     image_info?: ImageInfo;
     need_open_comment?: 0 | 1;

--- a/tests/core/parser/frontMatter.test.ts
+++ b/tests/core/parser/frontMatter.test.ts
@@ -9,6 +9,8 @@ description: This is a short summary.
 cover: https://example.com/image.png
 author: author_name
 source_url: http://source.com
+pic_crop_235_1: "0_0_1_1"
+pic_crop_1_1: "0_0_0.425532_1"
 need_open_comment: true
 only_fans_can_comment: true
 image_list:
@@ -31,6 +33,8 @@ Here is the rest of the post.`;
             content: "> This is a short summary.\n\n# Main Content\nHere is the rest of the post.",
             author: "author_name",
             source_url: "http://source.com",
+            pic_crop_235_1: "0_0_1_1",
+            pic_crop_1_1: "0_0_0.425532_1",
             need_open_comment: true,
             only_fans_can_comment: true,
             image_list: [

--- a/tests/node/publish.test.ts
+++ b/tests/node/publish.test.ts
@@ -110,12 +110,14 @@ describe("publish.ts tests", () => {
         ).rejects.toThrow(/41005: mock error/);
     });
 
-    it("should pass comment options to publishArticle", async () => {
+    it("should pass comment and crop options to publishArticle", async () => {
         const imgPath = path.join(__dirname, "../wenyan.jpg");
         await publishToWechatDraft({
-            title: "评论测试",
+            title: "选项测试",
             content: "<p>正文</p>",
             cover: imgPath,
+            pic_crop_235_1: "0_0_1_1",
+            pic_crop_1_1: "0_0_0.425532_1",
             need_open_comment: true,
             only_fans_can_comment: true,
         });
@@ -123,6 +125,8 @@ describe("publish.ts tests", () => {
         expect(mockWechatClient.publishArticle).toHaveBeenCalledWith(
             "mock_token",
             expect.objectContaining({
+                pic_crop_235_1: "0_0_1_1",
+                pic_crop_1_1: "0_0_0.425532_1",
                 need_open_comment: 1,
                 only_fans_can_comment: 1,
             }),


### PR DESCRIPTION
## Summary
- Add `pic_crop_235_1` and `pic_crop_1_1` to WeChat article publish options.
- Pass cover crop fields through `publishToWechatDraft` into the draft/add payload.
- Preserve crop fields from Markdown frontmatter and add regression coverage.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test
- [x] pnpm build